### PR TITLE
Add `mypy` to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ cutlery>=0.0.3,<0.1.0
 spacy>=3.4.0,<3.5.0
 srsly
 torch>=1.12.0
+mypy>=0.990,<0.1000; platform_machine != "aarch64" and python_version >= "3.7"
 
 # Development dependencies
 pytest


### PR DESCRIPTION
Copied from spaCy/requirements.txt. Should fix the Azure CI failures in #72.