### PR TITLE
Normalize identifiers that use `size` and `width` interchangeably

### DIFF
--- a/curated_transformers/models/pytorch/albert/config.py
+++ b/curated_transformers/models/pytorch/albert/config.py
@@ -22,10 +22,10 @@ class AlbertConfig(BertConfig):
     def __init__(
         self,
         *,
-        embedding_size: int = 128,
-        hidden_size: int = 768,
+        embedding_width: int = 128,
+        hidden_width: int = 768,
         inner_group_num: int = 1,
-        intermediate_size: int = 3072,
+        intermediate_width: int = 3072,
         num_attention_heads: int = 12,
         num_hidden_layers: int = 12,
         num_hidden_groups: int = 1,
@@ -40,7 +40,7 @@ class AlbertConfig(BertConfig):
         padding_idx: int = 0,
     ):
         self.embedding = BertEmbeddingConfig(
-            embedding_dim=embedding_size,
+            embedding_width=embedding_width,
             vocab_size=vocab_size,
             type_vocab_size=type_vocab_size,
             max_position_embeddings=max_position_embeddings,
@@ -48,14 +48,14 @@ class AlbertConfig(BertConfig):
             dropout_prob=hidden_dropout_prob,
         )
         self.attention = BertAttentionConfig(
-            hidden_size=hidden_size,
+            hidden_width=hidden_width,
             num_attention_heads=num_attention_heads,
             dropout_prob=attention_probs_dropout_prob,
         )
         self.layer = AlbertLayerConfig(
-            hidden_size=hidden_size,
+            hidden_width=hidden_width,
             inner_group_num=inner_group_num,
-            intermediate_size=intermediate_size,
+            intermediate_width=intermediate_width,
             num_hidden_layers=num_hidden_layers,
             num_hidden_groups=num_hidden_groups,
             hidden_act=hidden_act,

--- a/curated_transformers/models/pytorch/bert/config.py
+++ b/curated_transformers/models/pytorch/bert/config.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 
 @dataclass
 class BertEmbeddingConfig:
-    embedding_dim: int
+    embedding_width: int
     vocab_size: int
     type_vocab_size: int
     max_position_embeddings: int
@@ -17,14 +17,14 @@ class BertEmbeddingConfig:
     def __init__(
         self,
         *,
-        embedding_dim: int = 768,
+        embedding_width: int = 768,
         vocab_size: int = 30000,
         type_vocab_size: int = 2,
         max_position_embeddings: int = 512,
         layer_norm_eps: float = 1e-12,
         dropout_prob: float = 0.1,
     ) -> None:
-        self.embedding_dim = embedding_dim
+        self.embedding_width = embedding_width
         self.vocab_size = vocab_size
         self.type_vocab_size = type_vocab_size
         self.max_position_embeddings = max_position_embeddings
@@ -34,26 +34,26 @@ class BertEmbeddingConfig:
 
 @dataclass
 class BertAttentionConfig:
-    hidden_size: int
+    hidden_width: int
     num_attention_heads: int
     dropout_prob: float
 
     def __init__(
         self,
         *,
-        hidden_size: int = 768,
+        hidden_width: int = 768,
         num_attention_heads: int = 12,
         dropout_prob: float = 0.1,
     ) -> None:
-        self.hidden_size = hidden_size
+        self.hidden_width = hidden_width
         self.num_attention_heads = num_attention_heads
         self.dropout_prob = dropout_prob
 
 
 @dataclass
 class BertLayerConfig:
-    hidden_size: int
-    intermediate_size: int
+    hidden_width: int
+    intermediate_width: int
     num_hidden_layers: int
     hidden_act: str
     layer_norm_eps: float
@@ -62,15 +62,15 @@ class BertLayerConfig:
     def __init__(
         self,
         *,
-        hidden_size: int = 768,
-        intermediate_size: int = 3072,
+        hidden_width: int = 768,
+        intermediate_width: int = 3072,
         num_hidden_layers: int = 12,
         hidden_act: str = "gelu",
         layer_norm_eps: float = 1e-12,
         dropout_prob: float = 1.0,
     ) -> None:
-        self.hidden_size = hidden_size
-        self.intermediate_size = intermediate_size
+        self.hidden_width = hidden_width
+        self.intermediate_width = intermediate_width
         self.num_hidden_layers = num_hidden_layers
         self.hidden_act = hidden_act
         self.layer_norm_eps = layer_norm_eps
@@ -88,9 +88,9 @@ class BertConfig:
     def __init__(
         self,
         *,
-        embedding_dim: int = 768,
-        hidden_size: int = 768,
-        intermediate_size: int = 3072,
+        embedding_width: int = 768,
+        hidden_width: int = 768,
+        intermediate_width: int = 3072,
         num_attention_heads: int = 12,
         num_hidden_layers: int = 12,
         attention_probs_dropout_prob: float = 0.1,
@@ -104,7 +104,7 @@ class BertConfig:
         padding_idx: int = 0,
     ):
         self.embedding = BertEmbeddingConfig(
-            embedding_dim=embedding_dim,
+            embedding_width=embedding_width,
             vocab_size=vocab_size,
             type_vocab_size=type_vocab_size,
             max_position_embeddings=max_position_embeddings,
@@ -112,13 +112,13 @@ class BertConfig:
             dropout_prob=hidden_dropout_prob,
         )
         self.attention = BertAttentionConfig(
-            hidden_size=hidden_size,
+            hidden_width=hidden_width,
             num_attention_heads=num_attention_heads,
             dropout_prob=attention_probs_dropout_prob,
         )
         self.layer = BertLayerConfig(
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
+            hidden_width=hidden_width,
+            intermediate_width=intermediate_width,
             num_hidden_layers=num_hidden_layers,
             hidden_act=hidden_act,
             layer_norm_eps=layer_norm_eps,

--- a/curated_transformers/models/pytorch/bert/embeddings.py
+++ b/curated_transformers/models/pytorch/bert/embeddings.py
@@ -14,26 +14,26 @@ class BertEmbeddings(Module):
 
         self.word_embeddings = Embedding(
             num_embeddings=embedding_config.vocab_size,
-            embedding_dim=embedding_config.embedding_dim,
+            embedding_dim=embedding_config.embedding_width,
         )
         self.token_type_embeddings = Embedding(
             num_embeddings=embedding_config.type_vocab_size,
-            embedding_dim=embedding_config.embedding_dim,
+            embedding_dim=embedding_config.embedding_width,
         )
         self.position_embeddings = Embedding(
             num_embeddings=embedding_config.max_position_embeddings,
-            embedding_dim=embedding_config.embedding_dim,
+            embedding_dim=embedding_config.embedding_width,
         )
 
-        if embedding_config.embedding_dim != layer_config.hidden_size:
+        if embedding_config.embedding_width != layer_config.hidden_width:
             self.projection = Linear(
-                embedding_config.embedding_dim, layer_config.hidden_size
+                embedding_config.embedding_width, layer_config.hidden_width
             )
         else:
             self.projection = None  # type: ignore
 
         self.layer_norm = LayerNorm(
-            embedding_config.embedding_dim, eps=embedding_config.layer_norm_eps
+            embedding_config.embedding_width, eps=embedding_config.layer_norm_eps
         )
         self.dropout = Dropout(p=embedding_config.dropout_prob)
 

--- a/curated_transformers/models/pytorch/bert/layer.py
+++ b/curated_transformers/models/pytorch/bert/layer.py
@@ -12,7 +12,7 @@ class BertSelfAttention(Module):
     def __init__(self, config: BertAttentionConfig):
         super().__init__()
 
-        self.model_dim = config.hidden_size
+        self.model_dim = config.hidden_width
         self.num_heads = config.num_attention_heads
         if self.model_dim % self.num_heads != 0:
             raise ValueError(
@@ -73,9 +73,9 @@ class BertFeedForward(Module):
         super().__init__()
 
         self.intermediate = torch.nn.Linear(
-            config.hidden_size, config.intermediate_size
+            config.hidden_width, config.intermediate_width
         )
-        self.output = torch.nn.Linear(config.intermediate_size, config.hidden_size)
+        self.output = torch.nn.Linear(config.intermediate_width, config.hidden_width)
         if config.hidden_act == "relu":
             self.activation = torch.nn.ReLU()  # type: ignore
         elif config.hidden_act == "gelu":
@@ -108,12 +108,12 @@ class BertEncoderLayer(Module):
 
         self.mha = BertSelfAttention(attention_config)
         self.attn_output_layernorm = torch.nn.LayerNorm(
-            layer_config.hidden_size, eps=layer_config.layer_norm_eps
+            layer_config.hidden_width, eps=layer_config.layer_norm_eps
         )
         self.attn_output_dropout = torch.nn.Dropout(p=layer_config.dropout_prob)
         self.ffn = BertFeedForward(layer_config)
         self.ffn_output_layernorm = torch.nn.LayerNorm(
-            layer_config.hidden_size, eps=layer_config.layer_norm_eps
+            layer_config.hidden_width, eps=layer_config.layer_norm_eps
         )
         self.ffn_output_dropout = torch.nn.Dropout(p=layer_config.dropout_prob)
 

--- a/curated_transformers/models/scalar_weight.py
+++ b/curated_transformers/models/scalar_weight.py
@@ -58,10 +58,10 @@ def _convert_inputs(
     model: Model, X: ScalarWeightInT, is_train: bool = False
 ) -> Tuple[ArgsKwargs, Callable[[ArgsKwargs], List[Ragged]]]:
     ops = model.ops
-    layer_hidden_sizes = [x.data.shape[1] for x in X]
-    if not all_equal(layer_hidden_sizes):
+    layer_hidden_widths = [x.data.shape[1] for x in X]
+    if not all_equal(layer_hidden_widths):
         raise ValueError(
-            f"Not all hidden sizes are equal in input passed to scalar weight"
+            f"Not all hidden widths are equal in input passed to scalar weight"
         )
 
     Xops = ops.alloc3f(X[0].data.shape[0], len(X), X[0].data.shape[1])

--- a/curated_transformers/models/transformer_model.py
+++ b/curated_transformers/models/transformer_model.py
@@ -53,11 +53,11 @@ def build_albert_transformer_model_v1(
         SpanExtractorModelT,
     ],
     attention_probs_dropout_prob: float = 0.0,
-    embedding_size: int = 128,
+    embedding_width: int = 128,
     hidden_act: str = "gelu_new",
     hidden_dropout_prob: float = 0.0,
-    hidden_size: int = 768,
-    intermediate_size: int = 3072,
+    hidden_width: int = 768,
+    intermediate_width: int = 3072,
     layer_norm_eps: float = 1e-12,
     max_position_embeddings: int = 512,
     model_max_length: int = 512,
@@ -78,17 +78,17 @@ def build_albert_transformer_model_v1(
         Callback that constructs a span generator model.
     attention_probs_dropout_prob (float):
         Dropout probabilty of the self-attention layers.
-    embedding_size (int):
+    embedding_width (int):
         Width of the embedding representations.
     hidden_act (str):
         Activation used by the point-wise feed-forward layers.
     hidden_dropout_prob (float):
         Dropout probabilty of the point-wise feed-forward and
         embedding layers.
-    hidden_size (int):
+    hidden_width (int):
         Width of the final representations.
-    intermediate_size (int):
-        Size of the intermediate projection layer in the
+    intermediate_width (int):
+        Width of the intermediate projection layer in the
         point-wise feed-forward layer.
     layer_norm_eps (float):
         Epsilon for layer normalization.
@@ -114,9 +114,9 @@ def build_albert_transformer_model_v1(
         Configuration passed to the PyTorch gradient scaler.
     """
     config = AlbertConfig(
-        embedding_size=embedding_size,
-        hidden_size=hidden_size,
-        intermediate_size=intermediate_size,
+        embedding_width=embedding_width,
+        hidden_width=hidden_width,
+        intermediate_width=intermediate_width,
         num_attention_heads=num_attention_heads,
         num_hidden_groups=num_hidden_groups,
         num_hidden_layers=num_hidden_layers,
@@ -162,8 +162,8 @@ def build_bert_transformer_model_v1(
     attention_probs_dropout_prob: float = 0.1,
     hidden_act: str = "gelu",
     hidden_dropout_prob: float = 0.1,
-    hidden_size: int = 768,
-    intermediate_size: int = 3072,
+    hidden_width: int = 768,
+    intermediate_width: int = 3072,
     layer_norm_eps: float = 1e-12,
     max_position_embeddings: int = 512,
     model_max_length: int = 512,
@@ -188,10 +188,10 @@ def build_bert_transformer_model_v1(
     hidden_dropout_prob (float):
         Dropout probabilty of the point-wise feed-forward and
         embedding layers.
-    hidden_size (int):
+    hidden_width (int):
         Width of the final representations.
-    intermediate_size (int):
-        Size of the intermediate projection layer in the
+    intermediate_width (int):
+        Width of the intermediate projection layer in the
         point-wise feed-forward layer.
     layer_norm_eps (float):
         Epsilon for layer normalization.
@@ -215,8 +215,8 @@ def build_bert_transformer_model_v1(
         Configuration passed to the PyTorch gradient scaler.
     """
     config = BertConfig(
-        hidden_size=hidden_size,
-        intermediate_size=intermediate_size,
+        hidden_width=hidden_width,
+        intermediate_width=intermediate_width,
         num_attention_heads=num_attention_heads,
         num_hidden_layers=num_hidden_layers,
         attention_probs_dropout_prob=attention_probs_dropout_prob,
@@ -261,8 +261,8 @@ def build_camembert_transformer_model_v1(
     attention_probs_dropout_prob: float = 0.1,
     hidden_act: str = "gelu",
     hidden_dropout_prob: float = 0.1,
-    hidden_size: int = 768,
-    intermediate_size: int = 3072,
+    hidden_width: int = 768,
+    intermediate_width: int = 3072,
     layer_norm_eps: float = 1e-5,
     max_position_embeddings: int = 514,
     model_max_length: int = 512,
@@ -285,10 +285,10 @@ def build_camembert_transformer_model_v1(
     hidden_dropout_prob (float):
         Dropout probabilty of the point-wise feed-forward and
         embedding layers.
-    hidden_size (int):
+    hidden_width (int):
         Width of the final representations.
-    intermediate_size (int):
-        Size of the intermediate projection layer in the
+    intermediate_width (int):
+        Width of the intermediate projection layer in the
         point-wise feed-forward layer.
     layer_norm_eps (float):
         Epsilon for layer normalization.
@@ -314,8 +314,8 @@ def build_camembert_transformer_model_v1(
     piece_adapter = build_camembert_adapter()
 
     config = RobertaConfig(
-        hidden_size=hidden_size,
-        intermediate_size=intermediate_size,
+        hidden_width=hidden_width,
+        intermediate_width=intermediate_width,
         num_attention_heads=num_attention_heads,
         num_hidden_layers=num_hidden_layers,
         attention_probs_dropout_prob=attention_probs_dropout_prob,
@@ -357,8 +357,8 @@ def build_roberta_transformer_model_v1(
     attention_probs_dropout_prob: float = 0.1,
     hidden_act: str = "gelu",
     hidden_dropout_prob: float = 0.1,
-    hidden_size: int = 768,
-    intermediate_size: int = 3072,
+    hidden_width: int = 768,
+    intermediate_width: int = 3072,
     layer_norm_eps: float = 1e-5,
     max_position_embeddings: int = 514,
     model_max_length: int = 512,
@@ -383,10 +383,10 @@ def build_roberta_transformer_model_v1(
     hidden_dropout_prob (float):
         Dropout probabilty of the point-wise feed-forward and
         embedding layers.
-    hidden_size (int):
+    hidden_width (int):
         Width of the final representations.
-    intermediate_size (int):
-        Size of the intermediate projection layer in the
+    intermediate_width (int):
+        Width of the intermediate projection layer in the
         point-wise feed-forward layer.
     layer_norm_eps (float):
         Epsilon for layer normalization.
@@ -410,8 +410,8 @@ def build_roberta_transformer_model_v1(
         Configuration passed to the PyTorch gradient scaler.
     """
     config = RobertaConfig(
-        hidden_size=hidden_size,
-        intermediate_size=intermediate_size,
+        hidden_width=hidden_width,
+        intermediate_width=intermediate_width,
         num_attention_heads=num_attention_heads,
         num_hidden_layers=num_hidden_layers,
         attention_probs_dropout_prob=attention_probs_dropout_prob,
@@ -456,8 +456,8 @@ def build_xlmr_transformer_model_v1(
     attention_probs_dropout_prob: float = 0.1,
     hidden_act: str = "gelu",
     hidden_dropout_prob: float = 0.1,
-    hidden_size: int = 768,
-    intermediate_size: int = 3072,
+    hidden_width: int = 768,
+    intermediate_width: int = 3072,
     layer_norm_eps: float = 1e-5,
     max_position_embeddings: int = 514,
     model_max_length: int = 512,
@@ -482,10 +482,10 @@ def build_xlmr_transformer_model_v1(
     hidden_dropout_prob (float):
         Dropout probabilty of the point-wise feed-forward and
         embedding layers.
-    hidden_size (int):
+    hidden_width (int):
         Width of the final representations.
-    intermediate_size (int):
-        Size of the intermediate projection layer in the
+    intermediate_width (int):
+        Width of the intermediate projection layer in the
         point-wise feed-forward layer.
     layer_norm_eps (float):
         Epsilon for layer normalization.
@@ -511,8 +511,8 @@ def build_xlmr_transformer_model_v1(
     piece_adapter = build_xlmr_adapter()
 
     config = RobertaConfig(
-        hidden_size=hidden_size,
-        intermediate_size=intermediate_size,
+        hidden_width=hidden_width,
+        intermediate_width=intermediate_width,
         num_attention_heads=num_attention_heads,
         num_hidden_layers=num_hidden_layers,
         attention_probs_dropout_prob=attention_probs_dropout_prob,

--- a/curated_transformers/models/with_non_ws_tokens.py
+++ b/curated_transformers/models/with_non_ws_tokens.py
@@ -171,10 +171,10 @@ def _add_whitespace_tokens(
         if doc_alignment.has_no_whitespace:
             continue
 
-        hidden_size = Y_doc[0].dataXd.shape[1]
+        hidden_width = Y_doc[0].dataXd.shape[1]
         for layer_idx, layer in enumerate(Y_doc):
             lengths = []
-            new_layer = model.ops.alloc2f(doc_alignment.ws_n_pieces, hidden_size)
+            new_layer = model.ops.alloc2f(doc_alignment.ws_n_pieces, hidden_width)
 
             for alignment in doc_alignment:
                 if not alignment.is_whitespace:
@@ -201,9 +201,9 @@ def _remove_whitespace_tokens(
         if doc_alignment.has_no_whitespace:
             continue
 
-        hidden_size = cast(Tuple[int, ...], dY_doc[0].dataXd.shape)[1]
+        hidden_width = cast(Tuple[int, ...], dY_doc[0].dataXd.shape)[1]
         for layer_idx, layer in enumerate(dY_doc):
-            new_layer = model.ops.alloc2f(doc_alignment.no_ws_n_pieces, hidden_size)
+            new_layer = model.ops.alloc2f(doc_alignment.no_ws_n_pieces, hidden_width)
             lengths = []
 
             for alignment in doc_alignment:

--- a/curated_transformers/tests/models/test_transformer_model.py
+++ b/curated_transformers/tests/models/test_transformer_model.py
@@ -39,12 +39,12 @@ def toy_model(test_dir):
 @pytest.mark.parametrize("stride,window", [(2, 4), (96, 128)])
 @pytest.mark.parametrize("hf_model", [("xlm-roberta-base", 768, 250002)])
 def test_xlmr_model(sample_docs, stride, window, hf_model):
-    hf_model_name, hidden_size, vocab_size = hf_model
+    hf_model_name, hidden_width, vocab_size = hf_model
     with_spans = build_with_strided_spans_v1(stride=stride, window=window)
     model = build_xlmr_transformer_model_v1(
         with_spans=with_spans,
         vocab_size=vocab_size,
-        hidden_size=hidden_size,
+        hidden_width=hidden_width,
     )
     model.get_ref("transformer").init = build_hf_encoder_loader_v1(name=hf_model_name)
     model.get_ref("piece_encoder").init = build_hf_piece_encoder_loader_v1(
@@ -57,9 +57,9 @@ def test_xlmr_model(sample_docs, stride, window, hf_model):
     Y = Y.last_hidden_layer_states
     assert len(Y) == 2
     numpy.testing.assert_equal(Y[0].lengths, [1, 1, 1, 1, 1, 1, 2, 2])
-    assert Y[0].dataXd.shape == (10, hidden_size)
+    assert Y[0].dataXd.shape == (10, hidden_width)
     numpy.testing.assert_equal(Y[1].lengths, [1, 1, 1, 1, 2, 1, 2])
-    assert Y[1].dataXd.shape == (9, hidden_size)
+    assert Y[1].dataXd.shape == (9, hidden_width)
 
     # Backprop zeros to verify that backprop doesn't fail.
     dY = [
@@ -86,12 +86,12 @@ def test_xlmr_model(sample_docs, stride, window, hf_model):
 @pytest.mark.parametrize("stride,window", [(2, 4), (96, 128)])
 @pytest.mark.parametrize("hf_model", [("xlm-roberta-base", 768, 250002)])
 def test_input_with_spaces(sample_docs_with_spaces, stride, window, hf_model):
-    hidden_size = 768
+    hidden_width = 768
     with_spans = build_with_strided_spans_v1(stride=stride, window=window)
     model = build_xlmr_transformer_model_v1(
         with_spans=with_spans,
         vocab_size=250005,
-        hidden_size=hidden_size,
+        hidden_width=hidden_width,
         num_hidden_layers=1,
     )
     model.get_ref("piece_encoder").init = build_hf_piece_encoder_loader_v1(
@@ -104,9 +104,9 @@ def test_input_with_spaces(sample_docs_with_spaces, stride, window, hf_model):
     Y = Y.last_hidden_layer_states
     assert len(Y) == 2
     numpy.testing.assert_equal(Y[0].lengths, [1, 1, 1, 1, 1, 1, 1, 2, 2])
-    assert Y[0].dataXd.shape == (11, hidden_size)
+    assert Y[0].dataXd.shape == (11, hidden_width)
     numpy.testing.assert_equal(Y[1].lengths, [1, 1, 1, 1, 1, 1, 2, 1, 2, 1])
-    assert Y[1].dataXd.shape == (12, hidden_size)
+    assert Y[1].dataXd.shape == (12, hidden_width)
 
     # Backprop zeros to verify that backprop doesn't fail.
     dY = [

--- a/curated_transformers/tests/test_pipe.py
+++ b/curated_transformers/tests/test_pipe.py
@@ -47,7 +47,7 @@ cfg_string_last_layer_listener = """
 
     [components.tagger.model.tok2vec]
     @architectures = "curated-transformers.LastTransformerLayerListener.v1"
-    width = ${components.transformer.model.hidden_size}
+    width = ${components.transformer.model.hidden_width}
     pooling = {"@layers":"reduce_mean.v1"}
 
     [components.transformer]
@@ -58,7 +58,7 @@ cfg_string_last_layer_listener = """
     @architectures = "curated-transformers.BertTransformer.v1"
     vocab_size = 28996
     num_hidden_layers = 1
-    hidden_size = 60
+    hidden_width = 60
 
     [components.transformer.model.with_spans]
     @architectures = "curated-transformers.WithStridedSpans.v1"
@@ -92,7 +92,7 @@ cfg_string_scalar_weighting_layer_listener = """
 
     [components.tagger.model.tok2vec]
     @architectures = "curated-transformers.ScalarWeightingListener.v1"
-    width = ${components.transformer.model.hidden_size}
+    width = ${components.transformer.model.hidden_width}
     pooling = {"@layers":"reduce_mean.v1"}
 
     [components.tagger.model.tok2vec.weighting]
@@ -107,7 +107,7 @@ cfg_string_scalar_weighting_layer_listener = """
     @architectures = "curated-transformers.BertTransformer.v1"
     vocab_size = 28996
     num_hidden_layers = 1
-    hidden_size = 60
+    hidden_width = 60
 
     [components.transformer.model.with_spans]
     @architectures = "curated-transformers.WithStridedSpans.v1"


### PR DESCRIPTION
We always use `width` now, keeping it in-line with similar identifiers in spaCy.