### PR TITLE
Increase GPU throughput during gradient accumulation

### DIFF
--- a/curated_transformers/pipe.py
+++ b/curated_transformers/pipe.py
@@ -298,74 +298,9 @@ class Transformer(TrainablePipe):
         # To ensure that the model's internal state is always consistent with the pipe's.
         self._set_model_all_layer_outputs(self.all_layer_outputs)
 
-        if self.frozen:
-            # Ensures that the inner torch model is executed in a `no_grad` context.
-            outputs = self.model.predict(docs)
-            bp_outputs = None
-            d_outputs = None
-        else:
-            outputs, bp_outputs = self.model.begin_update(docs)
-            d_outputs = [
-                [
-                    Ragged(self.model.ops.alloc_f(t2v.dataXd.shape), t2v.lengths)
-                    for t2v in doc_layers
-                ]
-                for doc_layers in outputs.all_outputs
-            ]
-
-        def accumulate_gradient(
-            one_d_outputs: List[List[Ragged]], outputs_to_backprop: Tuple[int, ...]
-        ) -> None:
-            """Accumulate transformer loss and gradient. This is passed as a callback
-            to all but the last listener. Only the last one does the backprop.
-
-            `outputs_to_backprop` is a tuple of indices indicating to which layers/outputs
-            the gradients are to be propagated.
-            """
-            nonlocal d_outputs
-            assert d_outputs is not None
-            assert losses is not None
-            for i in range(len(one_d_outputs)):
-                for j in outputs_to_backprop:
-                    d_outputs[i][j].data += one_d_outputs[i][j].data
-                    losses[self.name] += float((one_d_outputs[i][j].data ** 2).sum())  # type: ignore
-
-        def accumulate_gradient_noop(
-            one_d_outputs: List[List[Ragged]], outputs_to_backprop: Tuple[int, ...]
-        ) -> None:
-            assert losses is not None
-            for i in range(len(one_d_outputs)):
-                for j in outputs_to_backprop:
-                    losses[self.name] += float((one_d_outputs[i][j].data ** 2).sum())  # type: ignore
-
-        def backprop(
-            one_d_outputs: List[List[Ragged]], outputs_to_backprop: Tuple[int, ...]
-        ) -> Any:
-            """Callback to actually do the backprop. Passed to last listener."""
-            nonlocal d_outputs
-            assert bp_outputs is not None
-            accumulate_gradient(one_d_outputs, outputs_to_backprop=outputs_to_backprop)
-            d_docs = bp_outputs(d_outputs)
-            if sgd is not None:
-                self.finish_update(sgd)
-            return d_docs
-
-        def backprop_noop(
-            one_d_outputs: List[List[Ragged]], outputs_to_backprop: Tuple[int, ...]
-        ) -> Any:
-            accumulate_gradient_noop(
-                one_d_outputs, outputs_to_backprop=outputs_to_backprop
-            )
-            if sgd is not None:
-                self.finish_update(sgd)
-            return []
-
-        if self.frozen:
-            accum_func = accumulate_gradient_noop
-            backprop_func = backprop_noop
-        else:
-            accum_func = accumulate_gradient
-            backprop_func = backprop
+        outputs, accum_func, backprop_func = self._create_backprops(
+            docs, losses, sgd=sgd
+        )
 
         batch_id = TransformerListener.get_batch_id(docs)
         for listener in self.listeners[:-1]:
@@ -427,6 +362,76 @@ class Transformer(TrainablePipe):
         """
         if not self.frozen:
             self.model.finish_update(sgd)
+
+    def _create_backprops(
+        self,
+        docs: Iterable[Doc],
+        losses: Dict[str, float],
+        *,
+        sgd: Optional[Optimizer] = None,
+    ) -> Tuple[TransformerModelOutput, Callable, Callable]:
+        ops = self.model.ops
+        # Accumulate the pipe's loss on the GPU at first.
+        cum_loss = ops.xp.full(1, losses[self.name])
+
+        if self.frozen:
+            # Ensures that the inner torch model is executed in a `no_grad` context.
+            outputs = self.model.predict(docs)
+            bp_outputs = None
+        else:
+            outputs, bp_outputs = self.model.begin_update(docs)
+
+        # We'll use this as a buffer for loss accumulation over individual gradients.
+        d_outputs = [
+            [Ragged(ops.alloc_f(t2v.dataXd.shape), t2v.lengths) for t2v in doc_layers]
+            for doc_layers in outputs.all_outputs
+        ]
+
+        def accumulate_gradient(
+            one_d_outputs: List[List[Ragged]], outputs_to_backprop: Tuple[int, ...]
+        ) -> None:
+            """Accumulate transformer loss and gradient. This is passed as a callback
+            to all but the last listener. Only the last one does the backprop.
+
+            `outputs_to_backprop` is a tuple of indices indicating to which layers/outputs
+            the gradients are to be propagated.
+            """
+            nonlocal d_outputs
+            for i in range(len(one_d_outputs)):
+                for j in outputs_to_backprop:
+                    d_outputs[i][j].data += one_d_outputs[i][j].data
+
+        def update_loss():
+            """Reduce the gradient buffer and update the losses dict."""
+            nonlocal cum_loss
+            for i in range(len(d_outputs)):
+                for j in range(len(d_outputs[i])):
+                    cum_loss += (d_outputs[i][j].data ** 2).sum()
+            losses[self.name] = float(cum_loss)
+
+        def backprop(
+            one_d_outputs: List[List[Ragged]], outputs_to_backprop: Tuple[int, ...]
+        ) -> Any:
+            """Callback to actually do the backprop. Passed to last listener."""
+            nonlocal d_outputs
+            assert bp_outputs is not None
+            accumulate_gradient(one_d_outputs, outputs_to_backprop=outputs_to_backprop)
+            update_loss()
+            d_docs = bp_outputs(d_outputs)
+            if sgd is not None:
+                self.finish_update(sgd)
+            return d_docs
+
+        def backprop_noop(
+            one_d_outputs: List[List[Ragged]], outputs_to_backprop: Tuple[int, ...]
+        ) -> Any:
+            accumulate_gradient(one_d_outputs, outputs_to_backprop=outputs_to_backprop)
+            update_loss()
+            if sgd is not None:
+                self.finish_update(sgd)
+            return []
+
+        return outputs, accumulate_gradient, backprop_noop if self.frozen else backprop
 
 
 def _install_extensions() -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Originally, we were updating the pipe's cumulative loss value for every layer being backpropagated into, for every listener. This resulted in significant overhead when using the `ScalarWeightingListener` as it led to a lot of consecutive kernel launches/teardowns and additional device-to-host copies.

Now, we merely accumulate the gradients from all listeners and calculate the loss once at the end of the accumulation phase. This improves the throughput of the `ScalarWeightingListener`'s backprop pass considerably, reducing spent GPU time spent from 11.6% to 3.6% (20% and 62% reduction in average and median ms/batch times respectively; I'm trying the nVidia method of up-selling the improvements :trollface:).

This PR also refactors the output and backprop calculation code into a separate helper method.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Refactor/Feature/Optimization

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
