### PR TITLE
`ScalarWeightListener`: Batch documents in forward and backward passes

### DIFF
--- a/curated_transformers/models/types.py
+++ b/curated_transformers/models/types.py
@@ -9,11 +9,11 @@ from .output import TransformerModelOutput
 PoolingModelT = Model[Ragged, Floats2d]
 
 WithRaggedLayersInT = Union[Iterable[Doc], Iterable[Iterable[Ragged]]]
-WithRaggedLayersOutT = List[List[Floats2d]]
+WithRaggedLayersOutT = List[List[Floats2d]]  # Doc -> Layer -> Representation
 WithRaggedLayersModelT = Model[WithRaggedLayersInT, WithRaggedLayersOutT]
 
 WithRaggedLastLayerInT = Union[Iterable[Doc], Iterable[Ragged]]
-WithRaggedLastLayerOutT = List[Floats2d]
+WithRaggedLastLayerOutT = List[Floats2d]  # Doc -> Last Layer Representation
 WithRaggedLastLayerModelT = Model[WithRaggedLastLayerInT, WithRaggedLastLayerOutT]
 
 
@@ -48,6 +48,6 @@ TransformerOutT = TransformerModelOutput
 TransformerBackpropT = Callable[[List[List[Floats2d]]], Any]
 TransformerModelT = Model[TransformerInT, TransformerOutT]
 
-ScalarWeightInT = List[List[Ragged]]
-ScalarWeightOutT = List[Ragged]
+ScalarWeightInT = List[List[Ragged]]  # Doc -> Layer -> Representation
+ScalarWeightOutT = List[Ragged]  # Doc -> Weighted Representation
 ScalarWeightModelT = Model[ScalarWeightInT, ScalarWeightOutT]

--- a/curated_transformers/models/types.py
+++ b/curated_transformers/models/types.py
@@ -48,6 +48,6 @@ TransformerOutT = TransformerModelOutput
 TransformerBackpropT = Callable[[List[List[Floats2d]]], Any]
 TransformerModelT = Model[TransformerInT, TransformerOutT]
 
-ScalarWeightInT = List[Ragged]
-ScalarWeightOutT = Ragged
+ScalarWeightInT = List[List[Ragged]]
+ScalarWeightOutT = List[Ragged]
 ScalarWeightModelT = Model[ScalarWeightInT, ScalarWeightOutT]

--- a/curated_transformers/tests/models/test_scalar_weight.py
+++ b/curated_transformers/tests/models/test_scalar_weight.py
@@ -18,29 +18,33 @@ def test_scalar_weight_model():
 
     lens = ops.asarray1i([1, 2, 3, 4, 5])
     X = [
-        Ragged(ones.copy(), lens.copy()),
-        Ragged(zeros.copy(), lens.copy()),
-        Ragged(ones.copy(), lens.copy()),
+        [
+            Ragged(ones.copy(), lens.copy()),
+            Ragged(zeros.copy(), lens.copy()),
+            Ragged(ones.copy(), lens.copy()),
+        ]
     ]
     Y = ops.alloc2f(15, 2) + (1.0 / 3.0) * 2
 
     Yh, backprop = model(X, is_train=True)
+    assert len(Yh) == 1
     ops.xp.testing.assert_equal(
-        Yh.dataXd,
+        Yh[0].dataXd,
         Y,
     )
     ops.xp.testing.assert_equal(
-        Yh.lengths,
+        Yh[0].lengths,
         lens,
     )
 
     dX = backprop(
-        Ragged(ones.copy(), lengths=lens.copy()),
+        [Ragged(ones.copy(), lengths=lens.copy())],
     )
     dX_expected = ops.alloc2f(15, 2) + (1.0 / 3.0)
 
-    assert len(dX) == 3
-    for dX_layer in dX:
+    assert len(dX) == 1
+    assert len(dX[0]) == 3
+    for dX_layer in dX[0]:
         ops.xp.testing.assert_equal(
             dX_layer.dataXd,
             dX_expected,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Similar to #77, this PR concatenates the layer outputs of all documents into a batched tensor before performing the scalar weighting on it. This speeds up the corresponding listeners to a small extent (50% reduction in median ms/batch though /nvidia-talk) during both training and distillation.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Feature

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
