### PR TITLE
Add `build_bert_wordpiece_encoder`

### DIFF
--- a/curated_transformers/models/architectures.py
+++ b/curated_transformers/models/architectures.py
@@ -32,7 +32,10 @@ from ..tokenization.sentencepiece_adapters import (
     build_xlmr_adapter,
 )
 from ..tokenization.sentencepiece_encoder import build_sentencepiece_encoder
-from ..tokenization.wordpiece_encoder import build_wordpiece_encoder
+from ..tokenization.wordpiece_encoder import (
+    build_bert_wordpiece_encoder,
+    build_wordpiece_encoder,
+)
 from ..tokenization.types import Tok2PiecesModelT, PieceAdapterModelT
 from .types import (
     TorchTransformerInT,
@@ -243,7 +246,7 @@ def build_bert_transformer_model_v1(
             grad_scaler_config=grad_scaler_config,
         )
 
-    piece_encoder = build_wordpiece_encoder()
+    piece_encoder = build_bert_wordpiece_encoder()
 
     return build_transformer_model_v1(
         with_spans=with_spans,

--- a/curated_transformers/tokenization/__init__.py
+++ b/curated_transformers/tokenization/__init__.py
@@ -1,4 +1,7 @@
 from .bbpe_encoder import build_byte_bpe_encoder_loader_v1
 from .hf_loader import build_hf_piece_encoder_loader_v1
 from .sentencepiece_encoder import build_sentencepiece_encoder_loader_v1
-from .wordpiece_encoder import build_wordpiece_encoder_loader_v1
+from .wordpiece_encoder import (
+    build_bert_wordpiece_encoder,
+    build_wordpiece_encoder_loader_v1,
+)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Huggingface BERT models preprocess strings by tokenizing them on punctuation characters. Since Huggingface tokenization has become the defacto tokenization for BERT models, we should provide the same type of tokenization to be compatible.

We expose the piecer with punctuation tokenization using a new `build_bert_wordpiece_encoder`, keeping `build_wordpiece_encoder` as a vanilla encoder.

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change

Enhancement.

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
