### PR TITLE
Move handling of adapters out of `build_transformer_model_v1`

### DIFF
--- a/curated_transformers/models/architectures.py
+++ b/curated_transformers/models/architectures.py
@@ -27,13 +27,13 @@ from .pytorch.roberta import RobertaConfig, RobertaEncoder
 from .remove_eos_bos import remove_bos_eos
 from .with_non_ws_tokens import with_non_ws_tokens
 from ..tokenization.bbpe_encoder import build_byte_bpe_encoder
-from ..tokenization.sentencepiece_adapters import (
-    build_camembert_adapter,
-    build_xlmr_adapter,
+from ..tokenization.sentencepiece_encoder import (
+    build_camembert_sentencepiece_encoder,
+    build_sentencepiece_encoder,
+    build_xlmr_sentencepiece_encoder,
 )
-from ..tokenization.sentencepiece_encoder import build_sentencepiece_encoder
 from ..tokenization.wordpiece_encoder import build_wordpiece_encoder
-from ..tokenization.types import Tok2PiecesModelT, PieceAdapterModelT
+from ..tokenization.types import Tok2PiecesModelT
 from .types import (
     TorchTransformerInT,
     TorchTransformerModelT,
@@ -312,8 +312,6 @@ def build_camembert_transformer_model_v1(
     grad_scaler_config (dict):
         Configuration passed to the PyTorch gradient scaler.
     """
-    piece_adapter = build_camembert_adapter()
-
     config = RobertaConfig(
         hidden_width=hidden_width,
         intermediate_width=intermediate_width,
@@ -338,12 +336,11 @@ def build_camembert_transformer_model_v1(
         encoder = RobertaEncoder(config)
         transformer = _pytorch_encoder(encoder)
 
-    piece_encoder = build_sentencepiece_encoder()
+    piece_encoder = build_camembert_sentencepiece_encoder()
 
     return build_transformer_model_v1(
         with_spans=with_spans,
         piece_encoder=piece_encoder,
-        piece_adapter=piece_adapter,
         transformer=transformer,
     )
 
@@ -509,8 +506,6 @@ def build_xlmr_transformer_model_v1(
     grad_scaler_config (dict):
         Configuration passed to the PyTorch gradient scaler.
     """
-    piece_adapter = build_xlmr_adapter()
-
     config = RobertaConfig(
         hidden_width=hidden_width,
         intermediate_width=intermediate_width,
@@ -539,12 +534,11 @@ def build_xlmr_transformer_model_v1(
             grad_scaler_config=grad_scaler_config,
         )
 
-    piece_encoder = build_sentencepiece_encoder()
+    piece_encoder = build_xlmr_sentencepiece_encoder()
 
     return build_transformer_model_v1(
         with_spans=with_spans,
         piece_encoder=piece_encoder,
-        piece_adapter=piece_adapter,
         transformer=transformer,
     )
 
@@ -557,27 +551,14 @@ def build_transformer_model_v1(
     ],
     transformer: TorchTransformerModelT,
     piece_encoder: Tok2PiecesModelT,
-    piece_adapter: Optional[PieceAdapterModelT] = None,
 ) -> TransformerModelT:
     # FIXME: do we want to make `remove_bos_eos` configurable as well or
     #        is it always the same post-processing?
-    if piece_adapter:
-        layers = [
-            with_non_ws_tokens(
-                chain(
-                    piece_encoder,
-                    piece_adapter,
-                    with_spans(transformer),
-                    remove_bos_eos(),
-                )
-            )
-        ]
-    else:
-        layers = [
-            with_non_ws_tokens(
-                chain(piece_encoder, with_spans(transformer), remove_bos_eos())
-            )
-        ]
+    layers = [
+        with_non_ws_tokens(
+            chain(piece_encoder, with_spans(transformer), remove_bos_eos())
+        )
+    ]
     refs = {
         "piece_encoder": piece_encoder,
         "transformer": transformer,

--- a/curated_transformers/tests/tokenization/test_xlmr_adapter.py
+++ b/curated_transformers/tests/tokenization/test_xlmr_adapter.py
@@ -10,6 +10,7 @@ from thinc.api import NumpyOps, Ragged, chain, Model
 from curated_transformers._compat import has_hf_transformers, transformers
 from curated_transformers.tokenization.sentencepiece_encoder import (
     build_sentencepiece_encoder,
+    build_xlmr_sentencepiece_encoder,
 )
 from curated_transformers.tokenization.sentencepiece_adapters import (
     build_xlmr_adapter,
@@ -27,14 +28,14 @@ def toy_model(test_dir):
 
 @pytest.fixture
 def toy_encoder(toy_model):
-    encoder = build_sentencepiece_encoder()
-    encoder.attrs["sentencepiece_processor"] = toy_model
-    return chain(encoder, build_xlmr_adapter())
+    encoder = build_xlmr_sentencepiece_encoder()
+    encoder.get_ref("encoder").attrs["sentencepiece_processor"] = toy_model
+    return encoder
 
 
 @pytest.fixture
 def empty_encoder():
-    return chain(build_sentencepiece_encoder(), build_xlmr_adapter())
+    return build_xlmr_sentencepiece_encoder()
 
 
 def _mock_transformer() -> Model[List[Ragged], TransformerModelOutput]:

--- a/curated_transformers/tokenization/hf_loader.py
+++ b/curated_transformers/tokenization/hf_loader.py
@@ -78,7 +78,9 @@ def _convert_sentencepiece_encoder(
     model: Tok2PiecesModelT,
     tokenizer: "transformers.RobertaTokenizerFast",
 ) -> Tok2PiecesModelT:
-    model.attrs["sentencepiece_processor"] = SentencePieceProcessor.from_file(
+    model.get_ref("encoder").attrs[
+        "sentencepiece_processor"
+    ] = SentencePieceProcessor.from_file(
         tokenizer.vocab_file  # type: ignore
     )
     return model

--- a/curated_transformers/tokenization/sentencepiece_encoder.py
+++ b/curated_transformers/tokenization/sentencepiece_encoder.py
@@ -1,7 +1,9 @@
 from typing import Callable, Optional, Tuple
 from pathlib import Path
 from cutlery import SentencePieceProcessor
-from thinc.api import Model, Ragged, deserialize_attr, serialize_attr
+from thinc.api import Model, Ragged, chain, deserialize_attr, serialize_attr
+
+from .sentencepiece_adapters import build_camembert_adapter, build_xlmr_adapter
 
 from .types import (
     Tok2PiecesBackpropT,
@@ -25,6 +27,20 @@ def deserialize_my_custom_class(
     return SentencePieceProcessor.from_protobuf(value)
 
 
+def build_camembert_sentencepiece_encoder() -> Tok2PiecesModelT:
+    """Construct a SentencePiece piece encoder model that accepts a list
+    of token sequences or documents and returns a corresponding list
+    of piece identifiers with CamemBERT post-processing applied.
+
+    This model must be separately initialized using an appropriate
+    loader.
+    """
+    encoder = build_sentencepiece_encoder()
+    model = chain(encoder, build_camembert_adapter())
+    model.set_ref("encoder", encoder)
+    return model
+
+
 def build_sentencepiece_encoder() -> Tok2PiecesModelT:
     """Construct a SentencePiece piece encoder model that accepts a list
     of token sequences or documents and returns a corresponding list
@@ -33,11 +49,27 @@ def build_sentencepiece_encoder() -> Tok2PiecesModelT:
     This model must be separately initialized using an appropriate
     loader.
     """
-    return Model(
+    model: Tok2PiecesModelT = Model(
         "sentencepiece_encoder",
         forward=sentencepiece_encoder_forward,
         attrs={"sentencepiece_processor": SentencePieceProcessor()},
     )
+    model.set_ref("encoder", model)
+    return model
+
+
+def build_xlmr_sentencepiece_encoder() -> Tok2PiecesModelT:
+    """Construct a SentencePiece piece encoder model that accepts a list
+    of token sequences or documents and returns a corresponding list
+    of piece identifiers with XLM-RoBERTa post-processing applied.
+
+    This model must be separately initialized using an appropriate
+    loader.
+    """
+    encoder = build_sentencepiece_encoder()
+    model = chain(encoder, build_xlmr_adapter())
+    model.set_ref("encoder", encoder)
+    return model
 
 
 def sentencepiece_encoder_forward(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

A chained piecer + adapter is just another `Tok2PiecesModelT`, so we should explose them in that we. Then downstream code can be oblivious to adapters. This change introduces two new constructors that a chained piecer + adapter:

- `build_camembert_sentencepiece_encoder`
- `build_xlmr_sentencepiece_encoder`

As a result, we can remove adapter handling from `build_transformer_model_v1`.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Refactor

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
