### PR TITLE
Revert "`with_strided_spans`: only break on token boundaries (#106)"

### DIFF
--- a/curated_transformers/models/with_strided_spans.py
+++ b/curated_transformers/models/with_strided_spans.py
@@ -1,7 +1,5 @@
-from dataclasses import dataclass
 from typing import Any, Callable, Iterable, List, Optional, Tuple, Union, cast
 from functools import partial
-from thinc.backends import NumpyOps
 from thinc.model import Model
 from thinc.types import Ragged, Floats2d, Ints1d
 
@@ -17,9 +15,6 @@ from .types import (
     TorchTransformerModelT,
     TorchTransformerOutT,
 )
-
-
-_NUMPY_OPS = NumpyOps()
 
 
 def build_with_strided_spans_v1(
@@ -53,7 +48,7 @@ def with_strided_spans(
             f"Stride must be within [window / 2, window] ([{window // 2}, {window}]), was: {stride}"
         )
     if batch_size <= 0:
-        raise ValueError("Span batch size must greater than zero")
+        raise ValueError(f"Span batch size must greater than zero")
 
     attrs = {
         "stride": stride,
@@ -78,12 +73,12 @@ def with_strided_spans_init(
     window: int = model.attrs["window"]
 
     X_spans = (
-        _ragged_to_strided_arrays(X, stride=stride, window=window).spans
+        _ragged_to_strided_arrays(X, stride=stride, window=window)[0]
         if X is not None
         else None
     )
     Y_spans = (
-        _ragged_to_strided_arrays(Y, stride=stride, window=window).spans
+        _ragged_to_strided_arrays(Y, stride=stride, window=window)[0]
         if Y is not None
         else None
     )
@@ -100,11 +95,13 @@ def with_strided_spans_forward(
     window: int = model.attrs["window"]
     batch_size: int = model.attrs["batch_size"]
 
-    span_data = _ragged_to_strided_arrays(Xlr=X, stride=stride, window=window)
+    spans, doc_lens = _ragged_to_strided_arrays(Xlr=X, stride=stride, window=window)
+    # Calculate once and use for all layer outputs.
+    doc_len_sums = [int(x.sum()) for x in doc_lens]
 
     backprops = []
     outputs = []
-    for batch in _split_spans(span_data.spans, batch_size):
+    for batch in _split_spans(spans, batch_size):
         output, bp = transformer(cast(TorchTransformerInT, batch), is_train=is_train)
         if not isinstance(output, TransformerModelOutput):
             raise ValueError(f"Unsupported input of type '{type(output)}'")
@@ -124,40 +121,43 @@ def with_strided_spans_forward(
     # average them in both representations.
     _apply_to_overlaps(
         trf_output.all_outputs,
-        docs_strides=span_data.docs_strides,
-        docs_windows=span_data.docs_windows,
+        doc_len_sums,
+        stride=stride,
+        window=window,
         func=_average_arrays,
     )
 
     model_output = _strided_arrays_to_ragged(
-        model,
-        trf_output.all_outputs,
-        span_data.doc_lens,
-        docs_strides=span_data.docs_strides,
+        model, trf_output.all_outputs, doc_lens, doc_len_sums, stride=stride
     )
     trf_output.all_outputs = cast(List[List[Ragged]], model_output)
 
     def backprop(dY: RaggedInOutT):
-        dY_span_data = _ragged_to_strided_arrays(dY, stride=stride, window=window)
+        dY_spans, dY_lengths = _ragged_to_strided_arrays(
+            dY, stride=stride, window=window
+        )
+        # Calculate once and use for all layer outputs.
+        dY_length_sums = [int(x.sum()) for x in dY_lengths]
 
         # Both overlaps will have dY. However, the proper gradient is 0.5 * dY
         # since we averaged the overlaps in the forward pass.
         _apply_to_overlaps(
-            dY_span_data.spans,
-            docs_strides=dY_span_data.docs_strides,
-            docs_windows=dY_span_data.docs_windows,
+            dY_spans,
+            dY_length_sums,
+            stride=stride,
+            window=window,
             func=_normalize_gradients,
         )
 
         dXlf = []
-        split_dY_spans = list(_split_spans(dY_span_data.spans, batch_size))
+        split_dY_spans = list(_split_spans(dY_spans, batch_size))
         assert len(split_dY_spans) == len(backprops)
         for dY_batch, bp_trf in zip(split_dY_spans, backprops):
             dXlf_batch = bp_trf(dY_batch)
             dXlf.extend(dXlf_batch)
 
         return _strided_arrays_to_ragged(
-            model, dXlf, dY_span_data.doc_lens, docs_strides=dY_span_data.docs_strides
+            model, dXlf, dY_lengths, dY_length_sums, stride=stride
         )
 
     return trf_output, backprop
@@ -184,34 +184,27 @@ def _unsplit_outputs(outputs: List[TorchTransformerOutT]) -> TorchTransformerOut
 
 def _apply_to_overlaps(
     Xlf: Floats2dInOutT,
+    len_sums: List[int],
     *,
-    docs_strides: List[Ints1d],
-    docs_windows: List[Ints1d],
+    stride: int,
+    window: int,
     func: Callable[[Any, Any], None],
 ):
     """Applies a function to overlapping windows, modifying the arrays
     in Xlf in-place."""
 
     def _apply_to_layer(input: Union[Tuple[Floats2d, ...], List[Floats2d]]):
-        for doc_strides, doc_windows in zip(docs_strides, docs_windows):
-            # Suppose that we have two spans:
-            #
-            # <--- stride1 --->
-            # <----- window1 ----->
-            #                  <--- stride2 --->
-            #                  <----- window2 ----->
-            #
-            # Then window1_overlap is the part of window1 that overlaps with
-            # window2, window2_overlap is the part of window2 that overlaps
-            # with window1.
-            window1_overlap = None
-            for stride, window in zip(doc_strides, doc_windows):
-                if window1_overlap is not None:
-                    window2_overlap = input[0][: window1_overlap.shape[0]]
-                    func(window1_overlap, window2_overlap)
+        for doc_len in len_sums:
+            prev_overlap = None
+            while doc_len != 0:
+                overlap = min(window - stride, doc_len)
+                if prev_overlap is not None:
+                    cur_overlap = input[0][:overlap]
+                    prev_overlap = prev_overlap[-overlap:]
+                    func(prev_overlap, cur_overlap)
+                prev_overlap = input[0][-overlap:]
 
-                overlap_len = window - stride
-                window1_overlap = input[0][-overlap_len:] if overlap_len else None
+                doc_len -= min(stride, doc_len)
                 input = input[1:]
 
     def _apply_to_layers(input: List[List[Floats2d]]):
@@ -220,6 +213,10 @@ def _apply_to_overlaps(
         transposed = list(zip(*input))
         for x in transposed:
             _apply_to_layer(x)
+
+    # Nothing to do if there is no overlap.
+    if window - stride == 0:
+        return
 
     if isinstance(Xlf[0], list):
         nested_list = cast(List[List[Floats2d]], Xlf)
@@ -240,51 +237,32 @@ def _normalize_gradients(array1, array2):
     array2 *= 0.5
 
 
-@dataclass
-class _Spans:
-    __slots__ = ["doc_lens", "docs_strides", "docs_windows", "spans"]
-
-    doc_lens: List[Ints1d]
-    docs_strides: List[Ints1d]
-    docs_windows: List[Ints1d]
-    spans: Floats2dInOutT
-
-
-def _ragged_to_strided_arrays(Xlr: RaggedInOutT, *, stride: int, window: int) -> _Spans:
+def _ragged_to_strided_arrays(
+    Xlr: RaggedInOutT, *, stride: int, window: int
+) -> Tuple[Floats2dInOutT, List[Ints1d]]:
     """Convert the per-Doc Ragged sequences to an array of sub-sequences that span
     all the input documents."""
 
     def _apply_to_layer(
-        input: Union[Tuple[Ragged, ...], List[Ragged]],
-        docs_strides: List[Ints1d],
-        docs_windows: List[Ints1d],
-        output: List[Floats2d],
+        input: Union[Tuple[Ragged, ...], List[Ragged]], output: List[Floats2d]
     ):
-        for Xr, doc_strides, doc_windows in zip(input, docs_strides, docs_windows):
+        for Xr in input:
             data = cast(Floats2d, Xr.dataXd)
-            for doc_stride, doc_window in zip(doc_strides, doc_windows):
-                output.append(data[:doc_window])
-                data = data[doc_stride:]
+            while data.shape[0] != 0:
+                output.append(data[:window])
+                data = data[stride:]
 
     def _apply_to_layers(input: List[List[Ragged]]):
         # Transpose input to reconstruct strides across all documents.
         transposed = list(zip(*Xlr))
         spans: List[List[Floats2d]] = [[] for _ in range(len(transposed))]
         lens = [x.lengths for x in transposed[0]]
-        docs_strides, docs_windows = _find_spans_with_token_boundaries(
-            transposed[0], stride, window
-        )
         for x, y in zip(transposed, spans):
-            _apply_to_layer(x, docs_strides, docs_windows, y)
+            _apply_to_layer(x, y)
 
         # Normalize sequences as lists.
         spans = [[y for y in x] for x in zip(*spans)]
-        return _Spans(
-            doc_lens=lens,
-            docs_strides=docs_strides,
-            docs_windows=docs_windows,
-            spans=spans,
-        )
+        return spans, lens
 
     if isinstance(Xlr[0], list):
         # Gradients in the backward pass.
@@ -294,37 +272,31 @@ def _ragged_to_strided_arrays(Xlr: RaggedInOutT, *, stride: int, window: int) ->
     else:
         # Inputs in the forward pass.
         flat_list = cast(List[Ragged], Xlr)
-        docs_strides, docs_windows = _find_spans_with_token_boundaries(
-            flat_list, stride, window
-        )
         spans: List[Floats2d] = []
         lens = [x.lengths for x in flat_list]
-        _apply_to_layer(flat_list, docs_strides, docs_windows, spans)
-        return _Spans(
-            doc_lens=lens,
-            docs_strides=docs_strides,
-            docs_windows=docs_windows,
-            spans=spans,
-        )
+        _apply_to_layer(flat_list, spans)
+        return spans, lens
 
 
 def _strided_arrays_to_ragged(
     model: Model,
     Xlf: Floats2dInOutT,
     lens: List[Ints1d],
+    len_sums: List[int],
     *,
-    docs_strides: List[Ints1d],
+    stride: int,
 ) -> RaggedInOutT:
     """Inverse operation of _ragged_to_strided_arrays."""
 
     def _apply_to_layer(
         input: Union[Tuple[Floats2d, ...], List[Floats2d]], output: List[Ragged]
     ):
-        for Xr_lens, doc_strides in zip(lens, docs_strides):
+        for doc_len, Xr_lens in zip(len_sums, lens):
             arrs = []
-            for stride in doc_strides:
-                arr = input[0][:stride]
+            while doc_len != 0:
+                arr = input[0][: min(stride, doc_len)]
                 arrs.append(arr)
+                doc_len -= arr.shape[0]
                 input = input[1:]
             output.append(Ragged(model.ops.flatten(arrs), lengths=Xr_lens))
 
@@ -349,51 +321,3 @@ def _strided_arrays_to_ragged(
         Xlr: List[Ragged] = []
         _apply_to_layer(flat_tuple, Xlr)
         return Xlr
-
-
-def _find_spans_with_token_boundaries(
-    Xlr: Union[Tuple[Ragged, ...], List[Ragged]], stride: int, window: int
-):
-    """When splitting inputs on a stride/window, we may be splitting up a
-    token consisting of multiple pieces. This function computes the
-    strides/windows rounded up to a token boundary."""
-    xp = _NUMPY_OPS.xp
-    docs_strides = []
-    docs_windows = []
-    for Xr in Xlr:
-        doc_strides = []
-        doc_windows = []
-
-        # We find the next boundary by first computing the cumulative
-        # sums of the token lengths. We can then (binary) search the token
-        # that lies on the stride/window boundary. Suppose that we have
-        # a stride of 128, there are three scenarios:
-        #
-        # 1. A particular token has a cumulative length of 128. In this case,
-        #    splitting on the stride wouldn't split up a token.
-        # 2. No token has a cumulative length of 128, but there is a token
-        #    with a cumulative length >128. The binary search will return the
-        #    index of the first token with length >128, say 130. We will then
-        #    use a stride of 130 to include the full token (in the current
-        #    span and exclude it in the next one).
-        # 3. There is no token with a cumulative length >=128. Binary search
-        #    will return the length of the array. In this case, we use the
-        #    remaining sequence.
-
-        cumsums = _NUMPY_OPS.asarray1i(xp.cumsum(Xr.lengths))
-        while cumsums.size:
-            indices = xp.searchsorted(cumsums, xp.array([stride, window]))
-            # Ensure that we don't index out of bounds in scenario (3).
-            vals = cumsums[xp.minimum(indices, cumsums.size - 1)]
-
-            doc_strides.append(vals[0])
-            doc_windows.append(vals[1])
-
-            # Re-use the cumulative sums for the next iteration.
-            cumsums = cumsums[indices[0] + 1 :]
-            cumsums -= vals[0]
-
-        docs_strides.append(_NUMPY_OPS.asarray1i(doc_strides))
-        docs_windows.append(_NUMPY_OPS.asarray1i(doc_windows))
-
-    return docs_strides, docs_windows

--- a/curated_transformers/tests/models/test_with_strided_spans.py
+++ b/curated_transformers/tests/models/test_with_strided_spans.py
@@ -31,12 +31,8 @@ def _add_range() -> Model[Floats2d, Floats2d]:
 
 def _mock_transformer() -> Model[List[Floats2d], TransformerModelOutput]:
     def forward(model: Model, X: List[Floats2d], is_train: bool):
-        model.attrs["last_input"] = X
-
         return (
-            TransformerModelOutput(
-                outputs=[[x.copy()] for x in X], last_layer_only=True
-            ),
+            TransformerModelOutput(outputs=[[x] for x in X], last_layer_only=True),
             lambda x: x,
         )
 
@@ -104,7 +100,7 @@ def test_with_strided_spans_averaging():
 
     ops.xp.testing.assert_equal(
         Y.all_outputs[0][0].dataXd,
-        [[0.0, 1.0], [2.0, 3.0], [4.0, 5.0], [9.0, 10.0], [11.0, 12.0], [13.0, 14.0]],
+        [[0.0, 1.0], [2.0, 3.0], [6.0, 7.0], [8.0, 9.0], [14.0, 15.0], [16.0, 17.0]],
     )
 
     ones = data + 1
@@ -118,79 +114,13 @@ def test_with_strided_spans_averaging():
         [
             [1.0, 1.0],
             [1.0, 1.0],
-            [1.0, 1.0],
+            [0.25, 0.25],
             [0.25, 0.25],
             [0.25, 0.25],
             [0.25, 0.25],
         ],
     )
     ops.xp.testing.assert_array_equal(dX[0].lengths, lengths)
-
-
-def test_with_strided_spans_respects_token_boundaries():
-    ops = NumpyOps()
-    data = ops.xp.arange(8, dtype="f").reshape(8, 1)
-    lengths = ops.asarray1i([2, 2, 2, 2])
-    X = [Ragged(data, lengths)]
-
-    transformer = _mock_transformer()
-
-    # We test three different scenarios: (1) the stride/window are on token
-    # boundaries; (2) the stride/window are not on token boundares; and (3) the
-    # stride/window are larger than the doc. We can verify correctness by
-    # checking the gradients, since they use both the stride and the window. But
-    # incorrect gradients are hard to debug, so we also check that the wrapped
-    # model sees the right windows.
-
-    # Stride and window correspond to token boundaries (except for the
-    # last window).
-    model_on_bounds = with_strided_spans(transformer, stride=2, window=4)
-    model_on_bounds.initialize(X)
-    _, backprop = model_on_bounds(X, is_train=True)
-    transformer_input = transformer.attrs["last_input"]
-    assert len(transformer_input) == 4
-    ops.xp.testing.assert_equal(transformer_input[0], data[:4])
-    ops.xp.testing.assert_equal(transformer_input[1], data[2:6])
-    ops.xp.testing.assert_equal(transformer_input[2], data[4:])
-    ops.xp.testing.assert_equal(transformer_input[3], data[6:])
-    dX = backprop(_copy_ragged(X))
-    assert len(dX) == 1
-    ops.xp.testing.assert_equal(
-        dX[0].dataXd,
-        ops.asarray2f([[0.0], [1.0], [0.5], [0.75], [1.0], [1.25], [1.5], [1.75]]),
-    )
-    ops.xp.testing.assert_equal(dX[0].lengths, lengths)
-
-    # Stride and window do not correspond to token boundaries.
-    model_in_tokens = with_strided_spans(transformer, stride=3, window=5)
-    model_in_tokens.initialize(X)
-    _, backprop = model_in_tokens(X, is_train=True)
-    transformer_input = transformer.attrs["last_input"]
-    assert len(transformer_input) == 2
-    ops.xp.testing.assert_equal(transformer_input[0], data[:6])
-    ops.xp.testing.assert_equal(transformer_input[1], data[4:])
-    dX = backprop(_copy_ragged(X))
-    assert len(dX) == 1
-    ops.xp.testing.assert_equal(
-        dX[0].dataXd,
-        ops.asarray2f([[0.0], [1.0], [2.0], [3.0], [1.0], [1.25], [6.0], [7.0]]),
-    )
-    ops.xp.testing.assert_equal(dX[0].lengths, lengths)
-
-    # Stride and window are longer than the doc.
-    model_large_span = with_strided_spans(transformer, stride=10, window=20)
-    model_large_span.initialize(X)
-    _, backprop = model_large_span(X, is_train=True)
-    transformer_input = transformer.attrs["last_input"]
-    assert len(transformer_input) == 1
-    ops.xp.testing.assert_equal(transformer_input[0], data)
-    dX = backprop(_copy_ragged(X))
-    assert len(dX) == 1
-    ops.xp.testing.assert_equal(
-        dX[0].dataXd,
-        X[0].dataXd,
-    )
-    ops.xp.testing.assert_equal(dX[0].lengths, lengths)
 
 
 def test_incorrect_strides_are_rejected():
@@ -207,7 +137,3 @@ def test_batch_sizes_are_rejected():
         with_strided_spans(relu, batch_size=-1)
     with pytest.raises(ValueError):
         with_strided_spans(relu, batch_size=0)
-
-
-def _copy_ragged(Xl: List[Ragged]) -> List[Ragged]:
-    return [Ragged(X.dataXd.copy(), X.lengths.copy()) for X in Xl]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This reverts commit 08a5d2de941259230e1fefe236f818716b74a9c4.

There were not tangible improvements from this change, but it does make span extraction less deterministic. With less predictable the input sizes/memory use are harder to control and the change in array sizes may lead to less efficient use of PyTorch memory pools.

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Maintenance

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
