### PR TITLE
Add optional `piece_encoder` argument to each transformer architecture

### DIFF
--- a/curated_transformers/models/architectures.py
+++ b/curated_transformers/models/architectures.py
@@ -26,16 +26,12 @@ from .pytorch.hf_util import convert_pretrained_model_for_encoder
 from .pytorch.roberta import RobertaConfig, RobertaEncoder
 from .remove_eos_bos import remove_bos_eos
 from .with_non_ws_tokens import with_non_ws_tokens
-from ..tokenization.bbpe_encoder import build_byte_bpe_encoder
-from ..tokenization.sentencepiece_encoder import (
-    build_camembert_sentencepiece_encoder,
-    build_sentencepiece_encoder,
-    build_xlmr_sentencepiece_encoder,
-)
-from ..tokenization.sentencepiece_encoder import build_sentencepiece_encoder
-from ..tokenization.wordpiece_encoder import (
-    build_bert_wordpiece_encoder,
-    build_wordpiece_encoder,
+from ..tokenization.bbpe_encoder import build_byte_bpe_encoder_v1
+from ..tokenization import (
+    build_bert_wordpiece_encoder_v1,
+    build_camembert_sentencepiece_encoder_v1,
+    build_sentencepiece_encoder_v1,
+    build_xlmr_sentencepiece_encoder_v1,
 )
 from ..tokenization.types import Tok2PiecesModelT
 from .types import (
@@ -148,7 +144,7 @@ def build_albert_transformer_model_v1(
             grad_scaler_config=grad_scaler_config,
         )
 
-    piece_encoder = build_sentencepiece_encoder()
+    piece_encoder = build_sentencepiece_encoder_v1()
 
     return build_transformer_model_v1(
         with_spans=with_spans,
@@ -247,7 +243,7 @@ def build_bert_transformer_model_v1(
             grad_scaler_config=grad_scaler_config,
         )
 
-    piece_encoder = build_bert_wordpiece_encoder()
+    piece_encoder = build_bert_wordpiece_encoder_v1()
 
     return build_transformer_model_v1(
         with_spans=with_spans,
@@ -340,7 +336,7 @@ def build_camembert_transformer_model_v1(
         encoder = RobertaEncoder(config)
         transformer = _pytorch_encoder(encoder)
 
-    piece_encoder = build_camembert_sentencepiece_encoder()
+    piece_encoder = build_camembert_sentencepiece_encoder_v1()
 
     return build_transformer_model_v1(
         with_spans=with_spans,
@@ -439,7 +435,7 @@ def build_roberta_transformer_model_v1(
             grad_scaler_config=grad_scaler_config,
         )
 
-    piece_encoder = build_byte_bpe_encoder()
+    piece_encoder = build_byte_bpe_encoder_v1()
 
     return build_transformer_model_v1(
         with_spans=with_spans,
@@ -538,7 +534,7 @@ def build_xlmr_transformer_model_v1(
             grad_scaler_config=grad_scaler_config,
         )
 
-    piece_encoder = build_xlmr_sentencepiece_encoder()
+    piece_encoder = build_xlmr_sentencepiece_encoder_v1()
 
     return build_transformer_model_v1(
         with_spans=with_spans,

--- a/curated_transformers/models/architectures.py
+++ b/curated_transformers/models/architectures.py
@@ -53,6 +53,7 @@ def build_albert_transformer_model_v1(
         [TorchTransformerModelT],
         SpanExtractorModelT,
     ],
+    piece_encoder: Optional[Tok2PiecesModelT] = None,
     attention_probs_dropout_prob: float = 0.0,
     embedding_width: int = 128,
     hidden_act: str = "gelu_new",
@@ -77,6 +78,8 @@ def build_albert_transformer_model_v1(
         Vocabulary size.
     with_spans (Callable):
         Callback that constructs a span generator model.
+    piece_encoder (Optional[Model])
+        Piece encoder, uses the default encoder for the model type when absent.
     attention_probs_dropout_prob (float):
         Dropout probabilty of the self-attention layers.
     embedding_width (int):
@@ -144,7 +147,9 @@ def build_albert_transformer_model_v1(
             grad_scaler_config=grad_scaler_config,
         )
 
-    piece_encoder = build_sentencepiece_encoder_v1()
+    piece_encoder = (
+        build_sentencepiece_encoder_v1() if piece_encoder is None else piece_encoder
+    )
 
     return build_transformer_model_v1(
         with_spans=with_spans,
@@ -160,6 +165,7 @@ def build_bert_transformer_model_v1(
         [TorchTransformerModelT],
         SpanExtractorModelT,
     ],
+    piece_encoder: Optional[Tok2PiecesModelT] = None,
     attention_probs_dropout_prob: float = 0.1,
     hidden_act: str = "gelu",
     hidden_dropout_prob: float = 0.1,
@@ -182,6 +188,8 @@ def build_bert_transformer_model_v1(
         Vocabulary size.
     with_spans (Callable):
         Callback that constructs a span generator model.
+    piece_encoder (Optional[Model])
+        Piece encoder, uses the default encoder for the model type when absent.
     attention_probs_dropout_prob (float):
         Dropout probabilty of the self-attention layers.
     hidden_act (str):
@@ -243,7 +251,9 @@ def build_bert_transformer_model_v1(
             grad_scaler_config=grad_scaler_config,
         )
 
-    piece_encoder = build_bert_wordpiece_encoder_v1()
+    piece_encoder = (
+        build_bert_wordpiece_encoder_v1() if piece_encoder is None else piece_encoder
+    )
 
     return build_transformer_model_v1(
         with_spans=with_spans,
@@ -259,6 +269,7 @@ def build_camembert_transformer_model_v1(
         [TorchTransformerModelT],
         SpanExtractorModelT,
     ],
+    piece_encoder: Optional[Tok2PiecesModelT] = None,
     attention_probs_dropout_prob: float = 0.1,
     hidden_act: str = "gelu",
     hidden_dropout_prob: float = 0.1,
@@ -279,6 +290,8 @@ def build_camembert_transformer_model_v1(
         Vocabulary size.
     with_spans (Callable):
         Callback that constructs a span generator model.
+    piece_encoder (Optional[Model])
+        Piece encoder, uses the default encoder for the model type when absent.
     attention_probs_dropout_prob (float):
         Dropout probabilty of the self-attention layers.
     hidden_act (str):
@@ -336,7 +349,11 @@ def build_camembert_transformer_model_v1(
         encoder = RobertaEncoder(config)
         transformer = _pytorch_encoder(encoder)
 
-    piece_encoder = build_camembert_sentencepiece_encoder_v1()
+    piece_encoder = (
+        build_camembert_sentencepiece_encoder_v1()
+        if piece_encoder is None
+        else piece_encoder
+    )
 
     return build_transformer_model_v1(
         with_spans=with_spans,
@@ -352,6 +369,7 @@ def build_roberta_transformer_model_v1(
         [TorchTransformerModelT],
         SpanExtractorModelT,
     ],
+    piece_encoder: Optional[Tok2PiecesModelT] = None,
     attention_probs_dropout_prob: float = 0.1,
     hidden_act: str = "gelu",
     hidden_dropout_prob: float = 0.1,
@@ -374,6 +392,8 @@ def build_roberta_transformer_model_v1(
         Vocabulary size.
     with_spans (Callable):
         Callback that constructs a span generator model.
+    piece_encoder (Optional[Model])
+        Piece encoder, uses the default encoder for the model type when absent.
     attention_probs_dropout_prob (float):
         Dropout probabilty of the self-attention layers.
     hidden_act (str):
@@ -435,7 +455,9 @@ def build_roberta_transformer_model_v1(
             grad_scaler_config=grad_scaler_config,
         )
 
-    piece_encoder = build_byte_bpe_encoder_v1()
+    piece_encoder = (
+        build_byte_bpe_encoder_v1() if piece_encoder is None else piece_encoder
+    )
 
     return build_transformer_model_v1(
         with_spans=with_spans,
@@ -451,6 +473,7 @@ def build_xlmr_transformer_model_v1(
         [TorchTransformerModelT],
         SpanExtractorModelT,
     ],
+    piece_encoder: Optional[Tok2PiecesModelT] = None,
     attention_probs_dropout_prob: float = 0.1,
     hidden_act: str = "gelu",
     hidden_dropout_prob: float = 0.1,
@@ -473,6 +496,8 @@ def build_xlmr_transformer_model_v1(
         Vocabulary size.
     with_spans (Callable):
         Callback that constructs a span generator model.
+    piece_encoder (Optional[Model])
+        Piece encoder, uses the default encoder for the model type when absent.
     attention_probs_dropout_prob (float):
         Dropout probabilty of the self-attention layers.
     hidden_act (str):
@@ -534,7 +559,11 @@ def build_xlmr_transformer_model_v1(
             grad_scaler_config=grad_scaler_config,
         )
 
-    piece_encoder = build_xlmr_sentencepiece_encoder_v1()
+    piece_encoder = (
+        build_xlmr_sentencepiece_encoder_v1()
+        if piece_encoder is None
+        else piece_encoder
+    )
 
     return build_transformer_model_v1(
         with_spans=with_spans,

--- a/curated_transformers/models/architectures.py
+++ b/curated_transformers/models/architectures.py
@@ -26,13 +26,6 @@ from .pytorch.hf_util import convert_pretrained_model_for_encoder
 from .pytorch.roberta import RobertaConfig, RobertaEncoder
 from .remove_eos_bos import remove_bos_eos
 from .with_non_ws_tokens import with_non_ws_tokens
-from ..tokenization.bbpe_encoder import build_byte_bpe_encoder_v1
-from ..tokenization import (
-    build_bert_wordpiece_encoder_v1,
-    build_camembert_sentencepiece_encoder_v1,
-    build_sentencepiece_encoder_v1,
-    build_xlmr_sentencepiece_encoder_v1,
-)
 from ..tokenization.types import Tok2PiecesModelT
 from .types import (
     TorchTransformerInT,
@@ -53,7 +46,7 @@ def build_albert_transformer_model_v1(
         [TorchTransformerModelT],
         SpanExtractorModelT,
     ],
-    piece_encoder: Optional[Tok2PiecesModelT] = None,
+    piece_encoder: Tok2PiecesModelT,
     attention_probs_dropout_prob: float = 0.0,
     embedding_width: int = 128,
     hidden_act: str = "gelu_new",
@@ -78,8 +71,8 @@ def build_albert_transformer_model_v1(
         Vocabulary size.
     with_spans (Callable):
         Callback that constructs a span generator model.
-    piece_encoder (Optional[Model])
-        Piece encoder, uses the default encoder for the model type when absent.
+    piece_encoder (Model)
+        The piece encoder to segment input tokens.
     attention_probs_dropout_prob (float):
         Dropout probabilty of the self-attention layers.
     embedding_width (int):
@@ -147,10 +140,6 @@ def build_albert_transformer_model_v1(
             grad_scaler_config=grad_scaler_config,
         )
 
-    piece_encoder = (
-        build_sentencepiece_encoder_v1() if piece_encoder is None else piece_encoder
-    )
-
     return build_transformer_model_v1(
         with_spans=with_spans,
         piece_encoder=piece_encoder,
@@ -165,7 +154,7 @@ def build_bert_transformer_model_v1(
         [TorchTransformerModelT],
         SpanExtractorModelT,
     ],
-    piece_encoder: Optional[Tok2PiecesModelT] = None,
+    piece_encoder: Tok2PiecesModelT,
     attention_probs_dropout_prob: float = 0.1,
     hidden_act: str = "gelu",
     hidden_dropout_prob: float = 0.1,
@@ -188,8 +177,8 @@ def build_bert_transformer_model_v1(
         Vocabulary size.
     with_spans (Callable):
         Callback that constructs a span generator model.
-    piece_encoder (Optional[Model])
-        Piece encoder, uses the default encoder for the model type when absent.
+    piece_encoder (Model)
+        The piece encoder to segment input tokens.
     attention_probs_dropout_prob (float):
         Dropout probabilty of the self-attention layers.
     hidden_act (str):
@@ -251,10 +240,6 @@ def build_bert_transformer_model_v1(
             grad_scaler_config=grad_scaler_config,
         )
 
-    piece_encoder = (
-        build_bert_wordpiece_encoder_v1() if piece_encoder is None else piece_encoder
-    )
-
     return build_transformer_model_v1(
         with_spans=with_spans,
         piece_encoder=piece_encoder,
@@ -269,7 +254,7 @@ def build_camembert_transformer_model_v1(
         [TorchTransformerModelT],
         SpanExtractorModelT,
     ],
-    piece_encoder: Optional[Tok2PiecesModelT] = None,
+    piece_encoder: Tok2PiecesModelT,
     attention_probs_dropout_prob: float = 0.1,
     hidden_act: str = "gelu",
     hidden_dropout_prob: float = 0.1,
@@ -290,8 +275,8 @@ def build_camembert_transformer_model_v1(
         Vocabulary size.
     with_spans (Callable):
         Callback that constructs a span generator model.
-    piece_encoder (Optional[Model])
-        Piece encoder, uses the default encoder for the model type when absent.
+    piece_encoder (Model)
+        The piece encoder to segment input tokens.
     attention_probs_dropout_prob (float):
         Dropout probabilty of the self-attention layers.
     hidden_act (str):
@@ -349,12 +334,6 @@ def build_camembert_transformer_model_v1(
         encoder = RobertaEncoder(config)
         transformer = _pytorch_encoder(encoder)
 
-    piece_encoder = (
-        build_camembert_sentencepiece_encoder_v1()
-        if piece_encoder is None
-        else piece_encoder
-    )
-
     return build_transformer_model_v1(
         with_spans=with_spans,
         piece_encoder=piece_encoder,
@@ -369,7 +348,7 @@ def build_roberta_transformer_model_v1(
         [TorchTransformerModelT],
         SpanExtractorModelT,
     ],
-    piece_encoder: Optional[Tok2PiecesModelT] = None,
+    piece_encoder: Tok2PiecesModelT,
     attention_probs_dropout_prob: float = 0.1,
     hidden_act: str = "gelu",
     hidden_dropout_prob: float = 0.1,
@@ -392,8 +371,8 @@ def build_roberta_transformer_model_v1(
         Vocabulary size.
     with_spans (Callable):
         Callback that constructs a span generator model.
-    piece_encoder (Optional[Model])
-        Piece encoder, uses the default encoder for the model type when absent.
+    piece_encoder (Model)
+        The piece encoder to segment input tokens.
     attention_probs_dropout_prob (float):
         Dropout probabilty of the self-attention layers.
     hidden_act (str):
@@ -455,10 +434,6 @@ def build_roberta_transformer_model_v1(
             grad_scaler_config=grad_scaler_config,
         )
 
-    piece_encoder = (
-        build_byte_bpe_encoder_v1() if piece_encoder is None else piece_encoder
-    )
-
     return build_transformer_model_v1(
         with_spans=with_spans,
         piece_encoder=piece_encoder,
@@ -473,7 +448,7 @@ def build_xlmr_transformer_model_v1(
         [TorchTransformerModelT],
         SpanExtractorModelT,
     ],
-    piece_encoder: Optional[Tok2PiecesModelT] = None,
+    piece_encoder: Tok2PiecesModelT,
     attention_probs_dropout_prob: float = 0.1,
     hidden_act: str = "gelu",
     hidden_dropout_prob: float = 0.1,
@@ -496,8 +471,8 @@ def build_xlmr_transformer_model_v1(
         Vocabulary size.
     with_spans (Callable):
         Callback that constructs a span generator model.
-    piece_encoder (Optional[Model])
-        Piece encoder, uses the default encoder for the model type when absent.
+    piece_encoder (Model)
+        The piece encoder to segment input tokens.
     attention_probs_dropout_prob (float):
         Dropout probabilty of the self-attention layers.
     hidden_act (str):
@@ -558,12 +533,6 @@ def build_xlmr_transformer_model_v1(
             mixed_precision=mixed_precision,
             grad_scaler_config=grad_scaler_config,
         )
-
-    piece_encoder = (
-        build_xlmr_sentencepiece_encoder_v1()
-        if piece_encoder is None
-        else piece_encoder
-    )
 
     return build_transformer_model_v1(
         with_spans=with_spans,

--- a/curated_transformers/pipeline/transformer.py
+++ b/curated_transformers/pipeline/transformer.py
@@ -29,6 +29,9 @@ DEFAULT_CONFIG_STR = """
     [transformer.model]
     @architectures = "curated-transformers.XlmrTransformer.v1"
 
+    [transformer.model.piece_encoder]
+    @architectures = "curated-transformers.XlmrSentencepieceEncoder.v1"
+
     [transformer.model.with_spans]
     @architectures = "curated-transformers.WithStridedSpans.v1"
 """

--- a/curated_transformers/tests/conftest.py
+++ b/curated_transformers/tests/conftest.py
@@ -2,7 +2,9 @@ from pathlib import Path
 import pytest
 import spacy
 
-from curated_transformers.tokenization.wordpiece_encoder import build_wordpiece_encoder
+from curated_transformers.tokenization.wordpiece_encoder import (
+    build_wordpiece_encoder_v1,
+)
 from curated_transformers.util import registry
 
 
@@ -64,7 +66,7 @@ def wordpiece_toy_model_path():
 
 @pytest.fixture
 def wordpiece_toy_encoder(wordpiece_toy_model_path):
-    encoder = build_wordpiece_encoder()
+    encoder = build_wordpiece_encoder_v1()
     encoder.init = registry.model_loaders.get(
         "curated-transformers.WordpieceLoader.v1"
     )(path=wordpiece_toy_model_path)

--- a/curated_transformers/tests/models/test_listeners.py
+++ b/curated_transformers/tests/models/test_listeners.py
@@ -24,9 +24,8 @@ cfg_string_transformer_layers_listener = """
     vocab_size = 28996
     num_hidden_layers = 2
     hidden_width = 60
-
-    [components.transformer.model.with_spans]
-    @architectures = "curated-transformers.WithStridedSpans.v1"
+    piece_encoder = {"@architectures":"curated-transformers.BertWordpieceEncoder.v1"}
+    with_spans = {"@architectures":"curated-transformers.WithStridedSpans.v1"}
 
     [initialize]
 

--- a/curated_transformers/tests/pipeline/test_transformer.py
+++ b/curated_transformers/tests/pipeline/test_transformer.py
@@ -20,7 +20,13 @@ from curated_transformers.models.hf_loader import build_hf_encoder_loader_v1
 from curated_transformers.models.with_strided_spans import (
     build_with_strided_spans_v1,
 )
-from curated_transformers.tokenization.hf_loader import build_hf_piece_encoder_loader_v1
+from curated_transformers.tokenization import (
+    build_bert_wordpiece_encoder_v1,
+    build_byte_bpe_encoder_v1,
+    build_camembert_sentencepiece_encoder_v1,
+    build_hf_piece_encoder_loader_v1,
+    build_xlmr_sentencepiece_encoder_v1,
+)
 from curated_transformers.pipeline.transformer import make_transformer
 from curated_transformers.util import create_gradual_transformer_unfreezing
 from curated_transformers._compat import has_hf_transformers, transformers
@@ -56,9 +62,8 @@ cfg_string_last_layer_listener = """
     vocab_size = 28996
     num_hidden_layers = 1
     hidden_width = 60
-
-    [components.transformer.model.with_spans]
-    @architectures = "curated-transformers.WithStridedSpans.v1"
+    piece_encoder = {"@architectures":"curated-transformers.BertWordpieceEncoder.v1"}
+    with_spans = {"@architectures":"curated-transformers.WithStridedSpans.v1"}
 
     [initialize]
 
@@ -105,9 +110,8 @@ cfg_string_scalar_weighting_layer_listener = """
     vocab_size = 28996
     num_hidden_layers = 1
     hidden_width = 60
-
-    [components.transformer.model.with_spans]
-    @architectures = "curated-transformers.WithStridedSpans.v1"
+    piece_encoder = {"@architectures":"curated-transformers.BertWordpieceEncoder.v1"}
+    with_spans = {"@architectures":"curated-transformers.WithStridedSpans.v1"}
 
     [initialize]
 
@@ -220,6 +224,7 @@ def _hf_tokenize_per_token(tokenizer, docs, *, roberta=False):
 def test_bert_transformer_pipe_against_hf():
     nlp = spacy.blank("en")
     model = build_bert_transformer_model_v1(
+        piece_encoder=build_bert_wordpiece_encoder_v1(),
         with_spans=build_with_strided_spans_v1(),
         vocab_size=28996,
     )
@@ -258,6 +263,7 @@ def test_bert_transformer_pipe_against_hf():
 def test_camembert_transformer_pipe_against_hf():
     nlp = spacy.blank("fr")
     model = build_camembert_transformer_model_v1(
+        piece_encoder=build_camembert_sentencepiece_encoder_v1(),
         with_spans=build_with_strided_spans_v1(),
         vocab_size=32005,
     )
@@ -296,6 +302,7 @@ def test_camembert_transformer_pipe_against_hf():
 def test_roberta_transformer_pipe_against_hf():
     nlp = spacy.blank("en")
     model = build_roberta_transformer_model_v1(
+        piece_encoder=build_byte_bpe_encoder_v1(),
         with_spans=build_with_strided_spans_v1(),
         vocab_size=50265,
     )
@@ -334,6 +341,7 @@ def test_roberta_transformer_pipe_against_hf():
 def test_xlmr_transformer_pipe_against_hf():
     nlp = spacy.blank("en")
     model = build_xlmr_transformer_model_v1(
+        piece_encoder=build_xlmr_sentencepiece_encoder_v1(),
         with_spans=build_with_strided_spans_v1(),
         vocab_size=250002,
     )
@@ -409,6 +417,7 @@ def test_frozen_transformer_pipe():
 def test_transformer_pipe_outputs():
     nlp = spacy.blank("en")
     model = build_xlmr_transformer_model_v1(
+        piece_encoder=build_xlmr_sentencepiece_encoder_v1(),
         with_spans=build_with_strided_spans_v1(),
         vocab_size=250002,
     )

--- a/curated_transformers/tests/pipeline/test_transformer.py
+++ b/curated_transformers/tests/pipeline/test_transformer.py
@@ -158,6 +158,11 @@ def evaluate_tagger_on_train_data(model):
     assert [t.tag_ for t in docs[1]] == ["N", "V", "J", "N"]
 
 
+def test_default_pipe_config_can_be_constructed():
+    nlp = spacy.blank("en")
+    nlp.add_pipe("curated_transformer", config={"model": {"vocab_size": 32}})
+
+
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 @pytest.mark.parametrize(

--- a/curated_transformers/tests/tokenization/test_bbpe_encoder.py
+++ b/curated_transformers/tests/tokenization/test_bbpe_encoder.py
@@ -2,14 +2,14 @@ import numpy.testing
 import pytest
 from thinc.api import Ragged, registry
 
-from curated_transformers.tokenization.bbpe_encoder import build_byte_bpe_encoder
+from curated_transformers.tokenization.bbpe_encoder import build_byte_bpe_encoder_v1
 from curated_transformers.tokenization.hf_loader import build_hf_piece_encoder_loader_v1
 from curated_transformers._compat import has_hf_transformers
 
 
 @pytest.fixture
 def toy_encoder(test_dir):
-    encoder = build_byte_bpe_encoder()
+    encoder = build_byte_bpe_encoder_v1()
     encoder.init = registry.model_loaders.get("curated-transformers.ByteBPELoader.v1")(
         vocab_path=test_dir / "toy-vocab.json", merges_path=test_dir / "toy-merges.txt"
     )
@@ -20,7 +20,7 @@ def toy_encoder(test_dir):
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_bbpe_encoder_hf_model(sample_docs):
-    encoder = build_byte_bpe_encoder()
+    encoder = build_byte_bpe_encoder_v1()
     encoder.init = build_hf_piece_encoder_loader_v1(name="roberta-base")
     encoder.initialize()
     encoding = encoder.predict(sample_docs)
@@ -34,7 +34,7 @@ def test_bbpe_encoder(toy_encoder, sample_docs):
 
 def test_serialize(toy_encoder):
     encoder_bytes = toy_encoder.to_bytes()
-    toy_encoder2 = build_byte_bpe_encoder()
+    toy_encoder2 = build_byte_bpe_encoder_v1()
     toy_encoder2.from_bytes(encoder_bytes)
     assert (
         toy_encoder.attrs["byte_bpe_processor"].vocab
@@ -49,11 +49,11 @@ def test_serialize(toy_encoder):
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_serialize_hf_model(sample_docs):
-    encoder = build_byte_bpe_encoder()
+    encoder = build_byte_bpe_encoder_v1()
     encoder.init = build_hf_piece_encoder_loader_v1(name="roberta-base")
     encoder.initialize()
     encoder_bytes = encoder.to_bytes()
-    encoder2 = build_byte_bpe_encoder()
+    encoder2 = build_byte_bpe_encoder_v1()
     encoder2.from_bytes(encoder_bytes)
     encoding = encoder2.predict(sample_docs)
     _check_roberta_base_encoder(encoding)

--- a/curated_transformers/tests/tokenization/test_registry.py
+++ b/curated_transformers/tests/tokenization/test_registry.py
@@ -32,5 +32,5 @@ def test_encoder_from_registry(encoder_name):
     ],
 )
 def test_encoder_loader_from_registry(loader_name):
-    # Can't be contstructed, since most loaders have mandatory arguments.
+    # Can't be constructed, since most loaders have mandatory arguments.
     registry.model_loaders.get(loader_name)

--- a/curated_transformers/tests/tokenization/test_registry.py
+++ b/curated_transformers/tests/tokenization/test_registry.py
@@ -1,0 +1,36 @@
+import pytest
+from spacy.util import registry as spacy_registry
+from curated_transformers.util import registry
+
+
+@pytest.mark.parametrize(
+    "encoder_name",
+    [
+        "curated-transformers.BertWordpieceEncoder.v1",
+        "curated-transformers.ByteBPEEncoder.v1",
+        "curated-transformers.CamembertSentencepieceEncoder.v1",
+        "curated-transformers.CharEncoder.v1",
+        "curated-transformers.SentencepieceEncoder.v1",
+        "curated-transformers.WordpieceEncoder.v1",
+        "curated-transformers.XlmrSentencepieceEncoder.v1",
+    ],
+)
+def test_encoder_from_registry(encoder_name):
+    spacy_registry.architectures.get(encoder_name)()
+
+
+@pytest.mark.parametrize(
+    "loader_name",
+    [
+        "curated-transformers.ByteBPELoader.v1",
+        "curated-transformers.CharEncoderLoader.v1",
+        "curated-transformers.HFEncoderLoader.v1",
+        "curated-transformers.HFPieceEncoderLoader.v1",
+        "curated-transformers.PyTorchCheckpointLoader.v1",
+        "curated-transformers.SentencepieceLoader.v1",
+        "curated-transformers.WordpieceLoader.v1",
+    ],
+)
+def test_encoder_loader_from_registry(loader_name):
+    # Can't be contstructed, since most loaders have mandatory arguments.
+    registry.model_loaders.get(loader_name)

--- a/curated_transformers/tests/tokenization/test_sentencepiece_encoder.py
+++ b/curated_transformers/tests/tokenization/test_sentencepiece_encoder.py
@@ -3,7 +3,7 @@ import pytest
 from thinc.api import Ragged, registry
 
 from curated_transformers.tokenization.sentencepiece_encoder import (
-    build_sentencepiece_encoder,
+    build_sentencepiece_encoder_v1,
 )
 from curated_transformers.tokenization.hf_loader import build_hf_piece_encoder_loader_v1
 from curated_transformers._compat import has_hf_transformers
@@ -16,7 +16,7 @@ def toy_model_path(test_dir):
 
 @pytest.fixture
 def toy_encoder(toy_model_path):
-    encoder = build_sentencepiece_encoder()
+    encoder = build_sentencepiece_encoder_v1()
     encoder.init = registry.model_loaders.get(
         "curated-transformers.SentencepieceLoader.v1"
     )(path=toy_model_path)
@@ -32,7 +32,7 @@ def test_sentencepiece_encoder(toy_encoder, sample_docs):
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_sentencepiece_encoder_hf_model(sample_docs):
-    encoder = build_sentencepiece_encoder()
+    encoder = build_sentencepiece_encoder_v1()
     encoder.init = build_hf_piece_encoder_loader_v1(name="xlm-roberta-base")
     encoder.initialize()
 
@@ -55,7 +55,7 @@ def test_sentencepiece_encoder_hf_model(sample_docs):
 
 def test_serialize(toy_encoder, sample_docs):
     encoder_bytes = toy_encoder.to_bytes()
-    encoder2 = build_sentencepiece_encoder()
+    encoder2 = build_sentencepiece_encoder_v1()
     encoder2.from_bytes(encoder_bytes)
     encoding = encoder2.predict(sample_docs)
     _check_toy_encoder(encoding)

--- a/curated_transformers/tests/tokenization/test_wordpiece_encoder.py
+++ b/curated_transformers/tests/tokenization/test_wordpiece_encoder.py
@@ -6,8 +6,8 @@ from thinc.api import Ragged
 
 from curated_transformers.tokenization.hf_loader import build_hf_piece_encoder_loader_v1
 from curated_transformers.tokenization.wordpiece_encoder import (
-    build_bert_wordpiece_encoder,
-    build_wordpiece_encoder,
+    build_bert_wordpiece_encoder_v1,
+    build_wordpiece_encoder_v1,
     _bert_preprocess,
     build_wordpiece_encoder_loader_v1,
 )
@@ -22,7 +22,7 @@ def test_wordpiece_encoder_local_model(wordpiece_toy_encoder, sample_docs):
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_wordpiece_encoder_hf_model(sample_docs):
-    encoder = build_wordpiece_encoder()
+    encoder = build_wordpiece_encoder_v1()
     encoder.init = build_hf_piece_encoder_loader_v1(name="bert-base-cased")
     encoder.initialize()
 
@@ -47,7 +47,7 @@ def test_wordpiece_encoder_hf_model(sample_docs):
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_wordpiece_encoder_hf_model_uncased(sample_docs):
-    encoder = build_wordpiece_encoder()
+    encoder = build_wordpiece_encoder_v1()
     encoder.init = build_hf_piece_encoder_loader_v1(name="bert-base-uncased")
     encoder.initialize()
 
@@ -71,7 +71,7 @@ def test_wordpiece_encoder_hf_model_uncased(sample_docs):
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_wordpiece_encoder_hf_model_german():
-    encoder = build_bert_wordpiece_encoder()
+    encoder = build_bert_wordpiece_encoder_v1()
     encoder.init = build_hf_piece_encoder_loader_v1(name="bert-base-german-cased")
     encoder.initialize()
 
@@ -102,7 +102,7 @@ def test_wordpiece_encoder_hf_model_german():
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_wordpiece_encoder_loader(sample_docs):
-    encoder = build_wordpiece_encoder()
+    encoder = build_wordpiece_encoder_v1()
     hf_tokenizer = transformers.AutoTokenizer.from_pretrained("bert-base-cased")
     with TemporaryDirectory() as d:
         vocab_path = hf_tokenizer.save_vocabulary(d)[0]
@@ -130,7 +130,7 @@ def test_wordpiece_encoder_loader(sample_docs):
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_wordpiece_encoder_loader_uncased(sample_docs):
-    encoder = build_wordpiece_encoder()
+    encoder = build_wordpiece_encoder_v1()
     hf_tokenizer = transformers.AutoTokenizer.from_pretrained("bert-base-uncased")
     with TemporaryDirectory() as d:
         vocab_path = hf_tokenizer.save_vocabulary(d)[0]
@@ -158,7 +158,7 @@ def test_wordpiece_encoder_loader_uncased(sample_docs):
 
 def test_serialize(wordpiece_toy_encoder):
     encoder_bytes = wordpiece_toy_encoder.to_bytes()
-    toy_encoder2 = build_wordpiece_encoder()
+    toy_encoder2 = build_wordpiece_encoder_v1()
     toy_encoder2.from_bytes(encoder_bytes)
     assert (
         wordpiece_toy_encoder.attrs["wordpiece_processor"].to_list()
@@ -169,11 +169,11 @@ def test_serialize(wordpiece_toy_encoder):
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_serialize_hf_model():
-    encoder = build_wordpiece_encoder()
+    encoder = build_wordpiece_encoder_v1()
     encoder.init = build_hf_piece_encoder_loader_v1(name="bert-base-cased")
     encoder.initialize()
     encoder_bytes = encoder.to_bytes()
-    encoder2 = build_wordpiece_encoder()
+    encoder2 = build_wordpiece_encoder_v1()
     encoder2.from_bytes(encoder_bytes)
     assert (
         encoder.attrs["wordpiece_processor"].to_list()

--- a/curated_transformers/tests/tokenization/test_xlmr_adapter.py
+++ b/curated_transformers/tests/tokenization/test_xlmr_adapter.py
@@ -6,13 +6,15 @@ from thinc.api import NumpyOps, Ragged, chain, Model
 
 from curated_transformers._compat import has_hf_transformers, transformers
 from curated_transformers.tokenization.sentencepiece_encoder import (
-    build_sentencepiece_encoder,
-    build_xlmr_sentencepiece_encoder,
+    build_sentencepiece_encoder_v1,
+    build_xlmr_sentencepiece_encoder_v1,
 )
 from curated_transformers.tokenization.sentencepiece_adapters import (
     build_xlmr_adapter,
 )
-from curated_transformers.tokenization.wordpiece_encoder import build_wordpiece_encoder
+from curated_transformers.tokenization.wordpiece_encoder import (
+    build_wordpiece_encoder_v1,
+)
 from curated_transformers.tokenization.hf_loader import build_hf_piece_encoder_loader_v1
 from curated_transformers.models.output import TransformerModelOutput
 from curated_transformers.models.remove_eos_bos import remove_bos_eos
@@ -25,14 +27,14 @@ def toy_model(test_dir):
 
 @pytest.fixture
 def toy_encoder(toy_model):
-    encoder = build_xlmr_sentencepiece_encoder()
+    encoder = build_xlmr_sentencepiece_encoder_v1()
     encoder.get_ref("encoder").attrs["sentencepiece_processor"] = toy_model
     return encoder
 
 
 @pytest.fixture
 def empty_encoder():
-    return build_xlmr_sentencepiece_encoder()
+    return build_xlmr_sentencepiece_encoder_v1()
 
 
 def _mock_transformer() -> Model[List[Ragged], TransformerModelOutput]:
@@ -70,7 +72,7 @@ def test_sentencepiece_encoder_against_hf(sample_docs):
     ops = NumpyOps()
 
     hf_tokenizer = transformers.AutoTokenizer.from_pretrained("xlm-roberta-base")
-    encoder = build_sentencepiece_encoder()
+    encoder = build_sentencepiece_encoder_v1()
     encoder.init = build_hf_piece_encoder_loader_v1(name="xlm-roberta-base")
     encoder.initialize()
     model = chain(encoder, build_xlmr_adapter(), _mock_transformer(), remove_bos_eos())
@@ -87,7 +89,7 @@ def test_sentencepiece_encoder_against_hf(sample_docs):
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_wordpiece_encoder_against_hf(sample_docs):
     ops = NumpyOps()
-    encoder = build_wordpiece_encoder()
+    encoder = build_wordpiece_encoder_v1()
     encoder.init = build_hf_piece_encoder_loader_v1(name="bert-base-cased")
     encoder.initialize()
     hf_tokenizer = transformers.AutoTokenizer.from_pretrained("bert-base-cased")

--- a/curated_transformers/tokenization/__init__.py
+++ b/curated_transformers/tokenization/__init__.py
@@ -1,8 +1,14 @@
-from .bbpe_encoder import build_byte_bpe_encoder_loader_v1
+from .bbpe_encoder import build_byte_bpe_encoder_loader_v1, build_byte_bpe_encoder_v1
 from .char_encoder import build_char_encoder_loader_v1, build_char_encoder_v1
 from .hf_loader import build_hf_piece_encoder_loader_v1
-from .sentencepiece_encoder import build_sentencepiece_encoder_loader_v1
+from .sentencepiece_encoder import (
+    build_camembert_sentencepiece_encoder_v1,
+    build_sentencepiece_encoder_loader_v1,
+    build_sentencepiece_encoder_v1,
+    build_xlmr_sentencepiece_encoder_v1,
+)
 from .wordpiece_encoder import (
-    build_bert_wordpiece_encoder,
+    build_bert_wordpiece_encoder_v1,
     build_wordpiece_encoder_loader_v1,
+    build_wordpiece_encoder_v1,
 )

--- a/curated_transformers/tokenization/bbpe_encoder.py
+++ b/curated_transformers/tokenization/bbpe_encoder.py
@@ -27,7 +27,7 @@ def deserialize_byte_bpe_processor(
     return ByteBPEProcessor(data["vocab"], data["merges"])
 
 
-def build_byte_bpe_encoder() -> Tok2PiecesModelT:
+def build_byte_bpe_encoder_v1() -> Tok2PiecesModelT:
     """Construct a Byte-BPE piece encoder model that accepts a list
     of token sequences or documents and returns a corresponding list
     of piece identifiers.

--- a/curated_transformers/tokenization/sentencepiece_encoder.py
+++ b/curated_transformers/tokenization/sentencepiece_encoder.py
@@ -27,7 +27,7 @@ def deserialize_my_custom_class(
     return SentencePieceProcessor.from_protobuf(value)
 
 
-def build_camembert_sentencepiece_encoder() -> Tok2PiecesModelT:
+def build_camembert_sentencepiece_encoder_v1() -> Tok2PiecesModelT:
     """Construct a SentencePiece piece encoder model that accepts a list
     of token sequences or documents and returns a corresponding list
     of piece identifiers with CamemBERT post-processing applied.
@@ -35,13 +35,13 @@ def build_camembert_sentencepiece_encoder() -> Tok2PiecesModelT:
     This model must be separately initialized using an appropriate
     loader.
     """
-    encoder = build_sentencepiece_encoder()
+    encoder = build_sentencepiece_encoder_v1()
     model = chain(encoder, build_camembert_adapter())
     model.set_ref("encoder", encoder)
     return model
 
 
-def build_sentencepiece_encoder() -> Tok2PiecesModelT:
+def build_sentencepiece_encoder_v1() -> Tok2PiecesModelT:
     """Construct a SentencePiece piece encoder model that accepts a list
     of token sequences or documents and returns a corresponding list
     of piece identifiers.
@@ -58,7 +58,7 @@ def build_sentencepiece_encoder() -> Tok2PiecesModelT:
     return model
 
 
-def build_xlmr_sentencepiece_encoder() -> Tok2PiecesModelT:
+def build_xlmr_sentencepiece_encoder_v1() -> Tok2PiecesModelT:
     """Construct a SentencePiece piece encoder model that accepts a list
     of token sequences or documents and returns a corresponding list
     of piece identifiers with XLM-RoBERTa post-processing applied.
@@ -66,7 +66,7 @@ def build_xlmr_sentencepiece_encoder() -> Tok2PiecesModelT:
     This model must be separately initialized using an appropriate
     loader.
     """
-    encoder = build_sentencepiece_encoder()
+    encoder = build_sentencepiece_encoder_v1()
     model = chain(encoder, build_xlmr_adapter())
     model.set_ref("encoder", encoder)
     return model

--- a/curated_transformers/tokenization/wordpiece_encoder.py
+++ b/curated_transformers/tokenization/wordpiece_encoder.py
@@ -27,7 +27,7 @@ def deserialize_my_custom_class(
     return WordPieceProcessor(value.decode("utf8").split("\n"))
 
 
-def build_bert_wordpiece_encoder() -> Tok2PiecesModelT:
+def build_bert_wordpiece_encoder_v1() -> Tok2PiecesModelT:
     """Construct a WordPiece piece encoder model that accepts a list
     of token sequences or documents and returns a corresponding list
     of piece identifiers. This encoder also splits each token
@@ -51,7 +51,7 @@ def build_bert_wordpiece_encoder() -> Tok2PiecesModelT:
     )
 
 
-def build_wordpiece_encoder() -> Tok2PiecesModelT:
+def build_wordpiece_encoder_v1() -> Tok2PiecesModelT:
     """Construct a WordPiece piece encoder model that accepts a list
     of token sequences or documents and returns a corresponding list
     of piece identifiers.

--- a/project/configs/layer-weighting.cfg
+++ b/project/configs/layer-weighting.cfg
@@ -123,6 +123,7 @@ all_layer_outputs = True
 vocab_size = 250002
 num_hidden_layers = 12
 hidden_size = 768
+piece_encoder = {"@architectures": "curated-transformers.XlmrSentencepieceEncoder.v1"}
 
 [components.transformer.model.with_spans]
 @architectures = "curated-transformers.WithStridedSpans.v1"

--- a/project/configs/no-layer-weighting.cfg
+++ b/project/configs/no-layer-weighting.cfg
@@ -100,6 +100,7 @@ factory = "curated_transformer"
 [components.transformer.model]
 @architectures = "curated-transformers.XlmrTransformer.v1"
 vocab_size = 250002
+piece_encoder = {"@architectures": "curated-transformers.XlmrSentencepieceEncoder.v1"}
 
 [components.transformer.model.with_spans]
 @architectures = "curated-transformers.WithStridedSpans.v1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,13 @@ spacy_architectures =
     curated-transformers.TransformerLayersListener.v1 = curated_transformers.models.listeners:build_transformer_layers_listener_v1
     curated-transformers.LastTransformerLayerListener.v1 = curated_transformers.models.listeners:build_last_transformer_layer_listener_v1
     curated-transformers.ScalarWeightingListener.v1 = curated_transformers.models.listeners:build_scalar_weighting_listener_v1
+    curated-transformers.BertWordpieceEncoder.v1 = curated_transformers.tokenization:build_bert_wordpiece_encoder_v1
+    curated-transformers.ByteBPEEncoder.v1 = curated_transformers.tokenization:build_byte_bpe_encoder_v1
+    curated-transformers.CamembertSentencepieceEncoder.v1 = curated_transformers.tokenization:build_camembert_sentencepiece_encoder_v1
+    curated-transformers.CharEncoder.v1 = curated_transformers.tokenization:build_char_encoder_v1
+    curated-transformers.SentencepieceEncoder.v1 = curated_transformers.tokenization:build_sentencepiece_encoder_v1
+    curated-transformers.WordpieceEncoder.v1 = curated_transformers.tokenization:build_wordpiece_encoder_v1
+    curated-transformers.XlmrSentencepieceEncoder.v1 = curated_transformers.tokenization:build_xlmr_sentencepiece_encoder_v1
 
 spacy_callbacks =
     curated-transformers.gradual_transformer_unfreezing.v1 = curated_transformers.util:create_gradual_transformer_unfreezing


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This allows a configuration to override the piece encoder that is used by the architecture, which is needed in rare cases. For instance, the `cl-tohoku/bert-base-japanese-char-v2` model uses a BERT transformer but a character-based piecer.

By default the `piece_encoder` value is `None`, which will use the default piece encoder for the architecture. This ensures that there is no configuration overhead in the vast majority of cases.

The PR also adds the piece encoders to the registry and tests whether they can be fetched from the registry in a specific test in `test_registry.py`.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Enhancement

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
