### PR TITLE
`tests`: Correctly handle GPU-resident tensors

### DIFF
--- a/curated_transformers/tests/models/test_pooling.py
+++ b/curated_transformers/tests/models/test_pooling.py
@@ -1,4 +1,5 @@
-from thinc.api import Ragged, reduce_sum
+from thinc.api import Ragged, reduce_sum, NumpyOps
+from thinc.util import convert_recursive, is_cupy_array
 
 from curated_transformers.models.pooling import (
     with_ragged_last_layer,
@@ -18,14 +19,15 @@ def test_with_ragged_last_layer():
 
     Y, backprop = pooler(docs, is_train=True)
 
-    ops.xp.testing.assert_equal(
+    for y, y_h in zip(
         Y,
         [
             ops.asarray2f([[1.0], [5.0]]),
             ops.asarray2f([[9.0], [6.0]]),
             ops.asarray2f([]).reshape(0, 1),
         ],
-    )
+    ):
+        ops.xp.testing.assert_array_equal(y, y_h)
 
     dX = backprop(
         [
@@ -37,19 +39,24 @@ def test_with_ragged_last_layer():
 
     assert len(dX) == 3
 
-    ops.xp.testing.assert_equal(dX[0].dataXd, ops.asarray2f([[1.0], [-1.0], [-1.0]]))
-    ops.xp.testing.assert_equal(dX[0].lengths, ops.asarray1i([1, 2]))
+    ops.xp.testing.assert_array_equal(
+        dX[0].dataXd, ops.asarray2f([[1.0], [-1.0], [-1.0]])
+    )
+    ops.xp.testing.assert_array_equal(dX[0].lengths, ops.asarray1i([1, 2]))
 
-    ops.xp.testing.assert_equal(dX[1].dataXd, ops.asarray2f([[-1.0], [-1.0], [1.0]]))
-    ops.xp.testing.assert_equal(dX[1].lengths, ops.asarray1i([2, 1]))
+    ops.xp.testing.assert_array_equal(
+        dX[1].dataXd, ops.asarray2f([[-1.0], [-1.0], [1.0]])
+    )
+    ops.xp.testing.assert_array_equal(dX[1].lengths, ops.asarray1i([2, 1]))
 
-    ops.xp.testing.assert_equal(dX[2].dataXd, ops.asarray2f([]).reshape(0, 1))
-    ops.xp.testing.assert_equal(dX[2].lengths, ops.asarray1i([]))
+    ops.xp.testing.assert_array_equal(dX[2].dataXd, ops.asarray2f([]).reshape(0, 1))
+    ops.xp.testing.assert_array_equal(dX[2].lengths, ops.asarray1i([]))
 
 
 def test_with_ragged_layers():
     pooler = with_ragged_layers(reduce_sum())
     ops = pooler.ops
+    numpy = NumpyOps().xp
 
     docs = [
         [
@@ -67,21 +74,24 @@ def test_with_ragged_layers():
     ]
 
     Y, backprop = pooler(docs, is_train=True)
+    # Since cupy balks at comparing sequences that mix CPU lists and GPU arrays,
+    # we'll need to convert them to numpy (CPU) arrays first.
+    Y = convert_recursive(is_cupy_array, lambda a: a.get(), Y)
 
-    ops.xp.testing.assert_equal(
+    numpy.testing.assert_equal(
         Y,
         [
             [
-                ops.asarray2f([[1.0], [5.0]]),
-                ops.asarray2f([[3.0], [3.0]]),
+                numpy.array([[1.0], [5.0]]),
+                numpy.array([[3.0], [3.0]]),
             ],
             [
-                ops.asarray2f([[9.0], [6.0]]),
-                ops.asarray2f([[11.0], [4.0]]),
+                numpy.array([[9.0], [6.0]]),
+                numpy.array([[11.0], [4.0]]),
             ],
             [
-                ops.asarray2f([]).reshape(0, 1),
-                ops.asarray2f([]).reshape(0, 1),
+                numpy.array([]).reshape(0, 1),
+                numpy.array([]).reshape(0, 1),
             ],
         ],
     )
@@ -106,19 +116,27 @@ def test_with_ragged_layers():
     assert len(dX) == 3
 
     assert len(dX[0]) == 2
-    ops.xp.testing.assert_equal(dX[0][0].dataXd, ops.asarray2f([[1.0], [-1.0], [-1.0]]))
-    ops.xp.testing.assert_equal(dX[0][0].lengths, ops.asarray1i([1, 2]))
-    ops.xp.testing.assert_equal(dX[0][1].dataXd, ops.asarray2f([[2.0], [-2.0], [-2.0]]))
-    ops.xp.testing.assert_equal(dX[0][1].lengths, ops.asarray1i([1, 2]))
+    ops.xp.testing.assert_array_equal(
+        dX[0][0].dataXd, ops.asarray2f([[1.0], [-1.0], [-1.0]])
+    )
+    ops.xp.testing.assert_array_equal(dX[0][0].lengths, ops.asarray1i([1, 2]))
+    ops.xp.testing.assert_array_equal(
+        dX[0][1].dataXd, ops.asarray2f([[2.0], [-2.0], [-2.0]])
+    )
+    ops.xp.testing.assert_array_equal(dX[0][1].lengths, ops.asarray1i([1, 2]))
 
     assert len(dX[1]) == 2
-    ops.xp.testing.assert_equal(dX[1][0].dataXd, ops.asarray2f([[-1.0], [-1.0], [1.0]]))
-    ops.xp.testing.assert_equal(dX[1][1].dataXd, ops.asarray2f([[-2.0], [-2.0], [2.0]]))
-    ops.xp.testing.assert_equal(dX[1][0].lengths, ops.asarray1i([2, 1]))
-    ops.xp.testing.assert_equal(dX[1][1].lengths, ops.asarray1i([2, 1]))
+    ops.xp.testing.assert_array_equal(
+        dX[1][0].dataXd, ops.asarray2f([[-1.0], [-1.0], [1.0]])
+    )
+    ops.xp.testing.assert_array_equal(
+        dX[1][1].dataXd, ops.asarray2f([[-2.0], [-2.0], [2.0]])
+    )
+    ops.xp.testing.assert_array_equal(dX[1][0].lengths, ops.asarray1i([2, 1]))
+    ops.xp.testing.assert_array_equal(dX[1][1].lengths, ops.asarray1i([2, 1]))
 
     assert len(dX[2]) == 2
-    ops.xp.testing.assert_equal(dX[2][0].dataXd, ops.asarray2f([]).reshape(0, 1))
-    ops.xp.testing.assert_equal(dX[2][1].dataXd, ops.asarray2f([]).reshape(0, 1))
-    ops.xp.testing.assert_equal(dX[2][0].lengths, ops.asarray1i([]))
-    ops.xp.testing.assert_equal(dX[2][1].lengths, ops.asarray1i([]))
+    ops.xp.testing.assert_array_equal(dX[2][0].dataXd, ops.asarray2f([]).reshape(0, 1))
+    ops.xp.testing.assert_array_equal(dX[2][1].dataXd, ops.asarray2f([]).reshape(0, 1))
+    ops.xp.testing.assert_array_equal(dX[2][0].lengths, ops.asarray1i([]))
+    ops.xp.testing.assert_array_equal(dX[2][1].lengths, ops.asarray1i([]))

--- a/curated_transformers/tests/models/test_scalar_weight.py
+++ b/curated_transformers/tests/models/test_scalar_weight.py
@@ -1,11 +1,11 @@
-from thinc.api import NumpyOps, Ragged
+from thinc.api import Ragged, get_current_ops
 import torch
 
 from curated_transformers.models.scalar_weight import build_scalar_weight_v1
 
 
 def test_scalar_weight_model():
-    ops = NumpyOps()
+    ops = get_current_ops()
     model = build_scalar_weight_v1(num_layers=2, dropout_prob=0.0)
 
     with torch.no_grad():
@@ -28,11 +28,11 @@ def test_scalar_weight_model():
 
     Yh, backprop = model(X, is_train=True)
     assert len(Yh) == 1
-    ops.xp.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(
         Yh[0].dataXd,
         Y,
     )
-    ops.xp.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(
         Yh[0].lengths,
         lens,
     )
@@ -45,11 +45,11 @@ def test_scalar_weight_model():
     assert len(dX) == 1
     assert len(dX[0]) == 3
     for dX_layer in dX[0]:
-        ops.xp.testing.assert_equal(
+        ops.xp.testing.assert_array_equal(
             dX_layer.dataXd,
             dX_expected,
         )
-        ops.xp.testing.assert_equal(
+        ops.xp.testing.assert_array_equal(
             dX_layer.lengths,
             lens,
         )

--- a/curated_transformers/tests/models/test_transformer_model.py
+++ b/curated_transformers/tests/models/test_transformer_model.py
@@ -1,4 +1,3 @@
-import numpy
 import pytest
 from cutlery import SentencePieceProcessor
 from thinc.api import CupyOps, NumpyOps, Ragged, registry
@@ -63,9 +62,9 @@ def test_xlmr_model(sample_docs, stride, window, hf_model):
     num_ouputs = Y.num_outputs
     Y = Y.last_hidden_layer_states
     assert len(Y) == 2
-    numpy.testing.assert_equal(Y[0].lengths, [1, 1, 1, 1, 1, 1, 2, 2])
+    model.ops.xp.testing.assert_array_equal(Y[0].lengths, [1, 1, 1, 1, 1, 1, 2, 2])
     assert Y[0].dataXd.shape == (10, hidden_width)
-    numpy.testing.assert_equal(Y[1].lengths, [1, 1, 1, 1, 2, 1, 2])
+    model.ops.xp.testing.assert_array_equal(Y[1].lengths, [1, 1, 1, 1, 2, 1, 2])
     assert Y[1].dataXd.shape == (9, hidden_width)
 
     # Backprop zeros to verify that backprop doesn't fail.
@@ -111,9 +110,11 @@ def test_input_with_spaces(sample_docs_with_spaces, stride, window, hf_model):
     num_ouputs = Y.num_outputs
     Y = Y.last_hidden_layer_states
     assert len(Y) == 2
-    numpy.testing.assert_equal(Y[0].lengths, [1, 1, 1, 1, 1, 1, 1, 2, 2])
+    model.ops.xp.testing.assert_array_equal(Y[0].lengths, [1, 1, 1, 1, 1, 1, 1, 2, 2])
     assert Y[0].dataXd.shape == (11, hidden_width)
-    numpy.testing.assert_equal(Y[1].lengths, [1, 1, 1, 1, 1, 1, 2, 1, 2, 1])
+    model.ops.xp.testing.assert_array_equal(
+        Y[1].lengths, [1, 1, 1, 1, 1, 1, 2, 1, 2, 1]
+    )
     assert Y[1].dataXd.shape == (12, hidden_width)
 
     # Backprop zeros to verify that backprop doesn't fail.

--- a/curated_transformers/tests/models/test_with_non_ws_tokens.py
+++ b/curated_transformers/tests/models/test_with_non_ws_tokens.py
@@ -42,14 +42,14 @@ def test_with_non_ws_tokens(sample_docs_with_spaces, wordpiece_toy_encoder):
     yl0 = Y.all_outputs[0][0]
     y1_check = model.ops.xp.ones((15, 2))
     y1_check[6, :] = 0.0
-    model.ops.xp.testing.assert_equal(yl0.dataXd, y1_check)
+    model.ops.xp.testing.assert_array_equal(yl0.dataXd, y1_check)
 
     yl1 = Y.all_outputs[1][0]
     y2_check = model.ops.xp.ones((17, 2))
     y2_check[4, :] = 0.0
     y2_check[8, :] = 0.0
     y2_check[16, :] = 0.0
-    model.ops.xp.testing.assert_equal(yl1.dataXd, y2_check)
+    model.ops.xp.testing.assert_array_equal(yl1.dataXd, y2_check)
 
     dY = [
         [
@@ -69,7 +69,7 @@ def test_with_non_ws_tokens(sample_docs_with_spaces, wordpiece_toy_encoder):
     backprop(dY)
 
     transformer_dY = mock_transformer.attrs["last_dY"]
-    model.ops.xp.testing.assert_equal(
+    model.ops.xp.testing.assert_array_equal(
         transformer_dY[0][0].dataXd,
         [
             [0.0, 0.0],
@@ -90,7 +90,7 @@ def test_with_non_ws_tokens(sample_docs_with_spaces, wordpiece_toy_encoder):
             [0.0, 0.0],
         ],
     )
-    model.ops.xp.testing.assert_equal(
+    model.ops.xp.testing.assert_array_equal(
         transformer_dY[1][0].dataXd,
         [
             [0.0, 0.0],

--- a/curated_transformers/tests/models/test_with_strided_spans.py
+++ b/curated_transformers/tests/models/test_with_strided_spans.py
@@ -1,7 +1,7 @@
 from typing import List
 from curated_transformers.models.output import TransformerModelOutput
 import pytest
-from thinc.api import Model, NumpyOps, Ragged, with_array, chain
+from thinc.api import Model, get_current_ops, Ragged, with_array, chain
 from thinc.types import Floats2d
 
 from curated_transformers.models.with_strided_spans import with_strided_spans
@@ -41,7 +41,7 @@ def _mock_transformer() -> Model[List[Floats2d], TransformerModelOutput]:
 
 @pytest.mark.parametrize("batch_size", [1, 2, 3, 5])
 def test_with_strided_spans(batch_size):
-    ops = NumpyOps()
+    ops = get_current_ops()
     trf = chain(with_array(relu_activation()), _mock_transformer())
     model = with_strided_spans(trf, stride=4, window=4, batch_size=batch_size)
 
@@ -86,7 +86,7 @@ def test_with_strided_spans(batch_size):
 
 
 def test_with_strided_spans_averaging():
-    ops = NumpyOps()
+    ops = get_current_ops()
     stateful = chain(with_array(_add_range()), _mock_transformer())
     model = with_strided_spans(stateful, stride=2, window=4)
 
@@ -98,7 +98,7 @@ def test_with_strided_spans_averaging():
 
     Y, backprop = model(X, is_train=False)
 
-    ops.xp.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(
         Y.all_outputs[0][0].dataXd,
         [[0.0, 1.0], [2.0, 3.0], [6.0, 7.0], [8.0, 9.0], [14.0, 15.0], [16.0, 17.0]],
     )

--- a/curated_transformers/tests/pipeline/test_transformer.py
+++ b/curated_transformers/tests/pipeline/test_transformer.py
@@ -374,6 +374,8 @@ def test_xlmr_transformer_pipe_against_hf():
         torch.testing.assert_close(
             hf_doc_encoding[:encoding_len][1:-1],
             torch.tensor(doc._.trf_data.last_hidden_layer_state.dataXd),
+            atol=1e-05,
+            rtol=1e-05,
         )
 
 

--- a/curated_transformers/tests/test_torchscript_wrapper.py
+++ b/curated_transformers/tests/test_torchscript_wrapper.py
@@ -6,11 +6,11 @@ from thinc.layers import (
     TorchScriptWrapper_v1,
     pytorch_to_torchscript_wrapper,
 )
+from thinc.api import get_array_module
 
 
 @pytest.mark.parametrize("nN,nI,nO", [(2, 3, 4)])
 def test_pytorch_script(nN, nI, nO):
-
     model = PyTorchWrapper_v2(Linear(nI, nO)).initialize()
 
     script_model = pytorch_to_torchscript_wrapper(model)
@@ -18,10 +18,11 @@ def test_pytorch_script(nN, nI, nO):
     X = numpy.random.randn(nN, nI).astype("f")
     Y = model.predict(X)
     Y_script = script_model.predict(X)
-    numpy.testing.assert_allclose(Y, Y_script)
+    xp = get_array_module(Y)
+    xp.testing.assert_array_equal(Y, Y_script)
 
     serialized = script_model.to_bytes()
     script_model2 = TorchScriptWrapper_v1()
     script_model2.from_bytes(serialized)
 
-    numpy.testing.assert_allclose(Y, script_model2.predict(X))
+    xp.testing.assert_array_equal(Y, script_model2.predict(X))

--- a/curated_transformers/tests/tokenization/test_bbpe_encoder.py
+++ b/curated_transformers/tests/tokenization/test_bbpe_encoder.py
@@ -1,6 +1,5 @@
-import numpy.testing
 import pytest
-from thinc.api import Ragged, registry
+from thinc.api import Ragged, registry, get_current_ops
 
 from curated_transformers.tokenization.bbpe_encoder import build_byte_bpe_encoder_v1
 from curated_transformers.tokenization.hf_loader import build_hf_piece_encoder_loader_v1
@@ -64,14 +63,17 @@ def _check_toy_encoder(encoding):
     assert len(encoding) == 2
 
     assert isinstance(encoding[0], Ragged)
-    numpy.testing.assert_equal(encoding[0].lengths, [1, 1, 1, 1, 3, 1, 1, 6, 1, 1])
-    numpy.testing.assert_equal(
+    ops = get_current_ops()
+    ops.xp.testing.assert_array_equal(
+        encoding[0].lengths, [1, 1, 1, 1, 3, 1, 1, 6, 1, 1]
+    )
+    ops.xp.testing.assert_array_equal(
         encoding[0].dataXd,
         [0, 44, 997, 262, 305, 334, 79, 342, 262, 388, 79, 302, 70, 472, 72, 17, 2],
     )
 
-    numpy.testing.assert_equal(encoding[1].lengths, [1, 3, 1, 1, 2, 4, 3, 1, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(encoding[1].lengths, [1, 3, 1, 1, 2, 4, 3, 1, 1])
+    ops.xp.testing.assert_array_equal(
         encoding[1].dataXd,
         [0, 55, 841, 321, 362, 579, 324, 294, 291, 494, 131, 106, 270, 307, 79, 17, 2],
     )
@@ -82,12 +84,15 @@ def _check_roberta_base_encoder(encoding):
     assert len(encoding) == 2
 
     assert isinstance(encoding[0], Ragged)
-    numpy.testing.assert_equal(encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-    numpy.testing.assert_equal(
+    ops = get_current_ops()
+    ops.xp.testing.assert_array_equal(
+        encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    )
+    ops.xp.testing.assert_array_equal(
         encoding[0].dataXd, [0, 100, 794, 10, 1816, 19, 10, 27608, 4, 2]
     )
 
-    numpy.testing.assert_equal(encoding[1].lengths, [1, 1, 1, 1, 1, 2, 1, 1, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(encoding[1].lengths, [1, 1, 1, 1, 1, 2, 1, 1, 1])
+    ops.xp.testing.assert_array_equal(
         encoding[1].dataXd, [0, 5625, 52, 40, 3529, 181, 48344, 5749, 4, 2]
     )

--- a/curated_transformers/tests/tokenization/test_char_encoder.py
+++ b/curated_transformers/tests/tokenization/test_char_encoder.py
@@ -1,6 +1,5 @@
-import numpy
 import pytest
-from thinc.api import Ragged
+from thinc.api import Ragged, get_current_ops
 import spacy
 
 from curated_transformers.tokenization.char_encoder import (
@@ -16,6 +15,7 @@ from curated_transformers._compat import has_fugashi, has_hf_transformers, has_s
 
 
 def test_char_encoder(test_dir):
+    ops = get_current_ops()
     encoder = build_char_encoder_v1()
     encoder.init = build_char_encoder_loader_v1(path=test_dir / "toy-chars.txt")
     encoder.initialize()
@@ -29,14 +29,14 @@ def test_char_encoder(test_dir):
     assert len(encoding) == 2
 
     assert isinstance(encoding[0], Ragged)
-    numpy.testing.assert_equal(encoding[0].lengths, [1, 5, 3, 4, 1, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(encoding[0].lengths, [1, 5, 3, 4, 1, 1])
+    ops.xp.testing.assert_array_equal(
         encoding[0].dataXd, [2, 56, 9, 9, 57, 18, 26, 5, 18, 24, 13, 14, 8, 1, 3]
     )
 
     assert isinstance(encoding[1], Ragged)
-    numpy.testing.assert_equal(encoding[1].lengths, [1, 5, 4, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(encoding[1].lengths, [1, 5, 4, 1])
+    ops.xp.testing.assert_array_equal(
         encoding[1].dataXd, [2, 37, 9, 1, 18, 8, 11, 9, 16, 8, 3]
     )
 
@@ -46,6 +46,7 @@ def test_char_encoder(test_dir):
 @pytest.mark.skipif(not has_fugashi, reason="requires fugashi")
 @pytest.mark.skipif(not has_sudachi, reason="requires SudachiPy and SudachiDict-core")
 def test_char_encoder_hf_model():
+    ops = get_current_ops()
     encoder = build_char_encoder_v1()
     encoder.init = registry.model_loaders.get(
         "curated-transformers.HFPieceEncoderLoader.v1"
@@ -61,11 +62,13 @@ def test_char_encoder_hf_model():
     assert len(encoding) == 2
 
     assert isinstance(encoding[0], Ragged)
-    numpy.testing.assert_equal(encoding[0].lengths, [1, 2, 1, 1, 1, 1])
-    numpy.testing.assert_equal(encoding[0].dataXd, [2, 2719, 2828, 4923, 882, 922, 3])
+    ops.xp.testing.assert_array_equal(encoding[0].lengths, [1, 2, 1, 1, 1, 1])
+    ops.xp.testing.assert_array_equal(
+        encoding[0].dataXd, [2, 2719, 2828, 4923, 882, 922, 3]
+    )
 
-    numpy.testing.assert_equal(encoding[1].lengths, [1, 2, 1, 1, 1, 2, 1, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(encoding[1].lengths, [1, 2, 1, 1, 1, 2, 1, 1])
+    ops.xp.testing.assert_array_equal(
         encoding[1].dataXd, [2, 1583, 5159, 897, 3574, 889, 852, 925, 829, 3]
     )
 

--- a/curated_transformers/tests/tokenization/test_sentencepiece_encoder.py
+++ b/curated_transformers/tests/tokenization/test_sentencepiece_encoder.py
@@ -1,6 +1,5 @@
-import numpy.testing
 import pytest
-from thinc.api import Ragged, registry
+from thinc.api import Ragged, registry, get_current_ops
 
 from curated_transformers.tokenization.sentencepiece_encoder import (
     build_sentencepiece_encoder_v1,
@@ -42,13 +41,16 @@ def test_sentencepiece_encoder_hf_model(sample_docs):
     assert len(encoding) == 2
 
     assert isinstance(encoding[0], Ragged)
-    numpy.testing.assert_equal(encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 2, 2, 1])
-    numpy.testing.assert_equal(
+    ops = get_current_ops()
+    ops.xp.testing.assert_array_equal(
+        encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 2, 2, 1]
+    )
+    ops.xp.testing.assert_array_equal(
         encoding[0].dataXd, [1, 86, 24123, 9, 23039, 677, 9, 5500, 70819, 5, 4, 2]
     )
 
-    numpy.testing.assert_equal(encoding[1].lengths, [1, 1, 1, 1, 1, 2, 1, 2, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(encoding[1].lengths, [1, 1, 1, 1, 1, 2, 1, 2, 1])
+    ops.xp.testing.assert_array_equal(
         encoding[1].dataXd, [1, 38395, 641, 1220, 73202, 159, 7663, 120323, 5, 4, 2]
     )
 
@@ -66,15 +68,18 @@ def _check_toy_encoder(encoding):
     assert len(encoding) == 2
 
     assert isinstance(encoding[0], Ragged)
-    numpy.testing.assert_equal(encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 6, 2, 1])
-    numpy.testing.assert_equal(
+    ops = get_current_ops()
+    ops.xp.testing.assert_array_equal(
+        encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 6, 2, 1]
+    )
+    ops.xp.testing.assert_array_equal(
         encoding[0].dataXd,
         [1, 8, 465, 10, 947, 41, 10, 170, 168, 110, 28, 20, 143, 7, 4, 2],
     )
 
     assert isinstance(encoding[1], Ragged)
-    numpy.testing.assert_equal(encoding[1].lengths, [1, 2, 1, 1, 1, 4, 3, 2, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(encoding[1].lengths, [1, 2, 1, 1, 1, 4, 3, 2, 1])
+    ops.xp.testing.assert_array_equal(
         encoding[1].dataXd,
         [1, 483, 546, 112, 171, 567, 62, 20, 45, 0, 84, 115, 27, 7, 4, 2],
     )

--- a/curated_transformers/tests/tokenization/test_wordpiece_encoder.py
+++ b/curated_transformers/tests/tokenization/test_wordpiece_encoder.py
@@ -1,8 +1,7 @@
-import numpy.testing
 import pytest
 import spacy
 from tempfile import TemporaryDirectory
-from thinc.api import Ragged
+from thinc.api import Ragged, get_current_ops
 
 from curated_transformers.tokenization.hf_loader import build_hf_piece_encoder_loader_v1
 from curated_transformers.tokenization.wordpiece_encoder import (
@@ -22,6 +21,7 @@ def test_wordpiece_encoder_local_model(wordpiece_toy_encoder, sample_docs):
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_wordpiece_encoder_hf_model(sample_docs):
+    ops = get_current_ops()
     encoder = build_wordpiece_encoder_v1()
     encoder.init = build_hf_piece_encoder_loader_v1(name="bert-base-cased")
     encoder.initialize()
@@ -32,13 +32,15 @@ def test_wordpiece_encoder_hf_model(sample_docs):
     assert len(encoding) == 2
 
     assert isinstance(encoding[0], Ragged)
-    numpy.testing.assert_equal(encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(
+        encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    )
+    ops.xp.testing.assert_array_equal(
         encoding[0].dataXd, [101, 146, 1486, 170, 1873, 1114, 170, 16737, 119, 102]
     )
 
-    numpy.testing.assert_equal(encoding[1].lengths, [1, 1, 1, 1, 1, 3, 1, 1, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(encoding[1].lengths, [1, 1, 1, 1, 1, 3, 1, 1, 1])
+    ops.xp.testing.assert_array_equal(
         encoding[1].dataXd,
         [101, 3570, 1195, 1209, 3940, 185, 5926, 2744, 7329, 119, 102],
     )
@@ -47,6 +49,7 @@ def test_wordpiece_encoder_hf_model(sample_docs):
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_wordpiece_encoder_hf_model_uncased(sample_docs):
+    ops = get_current_ops()
     encoder = build_wordpiece_encoder_v1()
     encoder.init = build_hf_piece_encoder_loader_v1(name="bert-base-uncased")
     encoder.initialize()
@@ -57,13 +60,15 @@ def test_wordpiece_encoder_hf_model_uncased(sample_docs):
     assert len(encoding) == 2
 
     assert isinstance(encoding[0], Ragged)
-    numpy.testing.assert_equal(encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(
+        encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    )
+    ops.xp.testing.assert_array_equal(
         encoding[0].dataXd, [101, 1045, 2387, 1037, 2611, 2007, 1037, 12772, 1012, 102]
     )
 
-    numpy.testing.assert_equal(encoding[1].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(encoding[1].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1])
+    ops.xp.testing.assert_array_equal(
         encoding[1].dataXd, [101, 2651, 2057, 2097, 4521, 26202, 4605, 1012, 102]
     )
 
@@ -71,6 +76,7 @@ def test_wordpiece_encoder_hf_model_uncased(sample_docs):
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_wordpiece_encoder_hf_model_german():
+    ops = get_current_ops()
     encoder = build_bert_wordpiece_encoder_v1()
     encoder.init = build_hf_piece_encoder_loader_v1(name="bert-base-german-cased")
     encoder.initialize()
@@ -87,13 +93,13 @@ def test_wordpiece_encoder_hf_model_german():
     assert len(encoding) == 2
 
     assert isinstance(encoding[0], Ragged)
-    numpy.testing.assert_equal(encoding[0].lengths, [1, 1, 1, 1, 5, 1, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(encoding[0].lengths, [1, 1, 1, 1, 5, 1, 1])
+    ops.xp.testing.assert_array_equal(
         encoding[0].dataXd, [3, 655, 2265, 39, 32, 26939, 26962, 26935, 2153, 26914, 4]
     )
 
-    numpy.testing.assert_equal(encoding[1].lengths, [1, 1, 5, 1, 1, 1, 1, 1, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(encoding[1].lengths, [1, 1, 5, 1, 1, 1, 1, 1, 1])
+    ops.xp.testing.assert_array_equal(
         encoding[1].dataXd,
         [3, 125, 56, 26915, 26914, 26935, 130, 26914, 4490, 141, 1028, 26914, 4],
     )
@@ -102,6 +108,7 @@ def test_wordpiece_encoder_hf_model_german():
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_wordpiece_encoder_loader(sample_docs):
+    ops = get_current_ops()
     encoder = build_wordpiece_encoder_v1()
     hf_tokenizer = transformers.AutoTokenizer.from_pretrained("bert-base-cased")
     with TemporaryDirectory() as d:
@@ -115,13 +122,15 @@ def test_wordpiece_encoder_loader(sample_docs):
     assert len(encoding) == 2
 
     assert isinstance(encoding[0], Ragged)
-    numpy.testing.assert_equal(encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(
+        encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    )
+    ops.xp.testing.assert_array_equal(
         encoding[0].dataXd, [101, 146, 1486, 170, 1873, 1114, 170, 16737, 119, 102]
     )
 
-    numpy.testing.assert_equal(encoding[1].lengths, [1, 1, 1, 1, 1, 3, 1, 1, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(encoding[1].lengths, [1, 1, 1, 1, 1, 3, 1, 1, 1])
+    ops.xp.testing.assert_array_equal(
         encoding[1].dataXd,
         [101, 3570, 1195, 1209, 3940, 185, 5926, 2744, 7329, 119, 102],
     )
@@ -130,6 +139,7 @@ def test_wordpiece_encoder_loader(sample_docs):
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_wordpiece_encoder_loader_uncased(sample_docs):
+    ops = get_current_ops()
     encoder = build_wordpiece_encoder_v1()
     hf_tokenizer = transformers.AutoTokenizer.from_pretrained("bert-base-uncased")
     with TemporaryDirectory() as d:
@@ -145,13 +155,15 @@ def test_wordpiece_encoder_loader_uncased(sample_docs):
     assert len(encoding) == 2
 
     assert isinstance(encoding[0], Ragged)
-    numpy.testing.assert_equal(encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(
+        encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    )
+    ops.xp.testing.assert_array_equal(
         encoding[0].dataXd, [101, 1045, 2387, 1037, 2611, 2007, 1037, 12772, 1012, 102]
     )
 
-    numpy.testing.assert_equal(encoding[1].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(encoding[1].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1])
+    ops.xp.testing.assert_array_equal(
         encoding[1].dataXd, [101, 2651, 2057, 2097, 4521, 26202, 4605, 1012, 102]
     )
 
@@ -191,18 +203,21 @@ def test_bert_preprocess():
 
 
 def _check_toy_encoder(encoding):
+    ops = get_current_ops()
     assert isinstance(encoding, list)
     assert len(encoding) == 2
 
     assert isinstance(encoding[0], Ragged)
-    numpy.testing.assert_equal(encoding[0].lengths, [1, 1, 1, 1, 3, 1, 1, 5, 1, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(
+        encoding[0].lengths, [1, 1, 1, 1, 3, 1, 1, 5, 1, 1]
+    )
+    ops.xp.testing.assert_array_equal(
         encoding[0].dataXd,
         [2, 41, 818, 61, 67, 193, 88, 204, 61, 251, 909, 682, 102, 95, 17, 3],
     )
 
-    numpy.testing.assert_equal(encoding[1].lengths, [1, 3, 1, 1, 2, 3, 3, 1, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(encoding[1].lengths, [1, 3, 1, 1, 2, 3, 3, 1, 1])
+    ops.xp.testing.assert_array_equal(
         encoding[1].dataXd,
         [2, 824, 98, 189, 311, 417, 65, 155, 503, 99, 1, 416, 117, 88, 17, 3],
     )

--- a/curated_transformers/tests/tokenization/test_xlmr_adapter.py
+++ b/curated_transformers/tests/tokenization/test_xlmr_adapter.py
@@ -1,8 +1,8 @@
 from typing import List
 from cutlery import SentencePieceProcessor
-import numpy.testing
 import pytest
-from thinc.api import NumpyOps, Ragged, chain, Model
+from thinc.api import Ragged, chain, Model, get_current_ops, NumpyOps
+from thinc.util import convert_recursive, is_cupy_array
 
 from curated_transformers._compat import has_hf_transformers, transformers
 from curated_transformers.tokenization.sentencepiece_encoder import (
@@ -61,15 +61,22 @@ def test_serialize(toy_encoder, empty_encoder, sample_docs):
 
 
 def _compare_model_hf_output(ops, Y, Y_hf):
+    numpy = NumpyOps().xp
     # Get inputs, removing BOS/EOS from every token.
-    Y_hf = [e[1:-1] for e in Y_hf["input_ids"]]
-    numpy.testing.assert_equal(ops.unflatten(Y.dataXd, Y.lengths), Y_hf)
+    Y_hf = [numpy.array(e[1:-1]) for e in Y_hf["input_ids"]]
+
+    # Since cupy balks at comparing sequences that mix CPU lists and GPU arrays,
+    # we'll need to convert them to numpy (CPU) arrays first.
+    Y = convert_recursive(
+        is_cupy_array, lambda a: a.get(), ops.unflatten(Y.dataXd, Y.lengths)
+    )
+    numpy.testing.assert_equal(Y, Y_hf)
 
 
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_sentencepiece_encoder_against_hf(sample_docs):
-    ops = NumpyOps()
+    ops = get_current_ops()
 
     hf_tokenizer = transformers.AutoTokenizer.from_pretrained("xlm-roberta-base")
     encoder = build_sentencepiece_encoder_v1()
@@ -88,7 +95,7 @@ def test_sentencepiece_encoder_against_hf(sample_docs):
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_wordpiece_encoder_against_hf(sample_docs):
-    ops = NumpyOps()
+    ops = get_current_ops()
     encoder = build_wordpiece_encoder_v1()
     encoder.init = build_hf_piece_encoder_loader_v1(name="bert-base-cased")
     encoder.initialize()
@@ -108,15 +115,18 @@ def _check_encoder(encoding):
     assert len(encoding) == 2
 
     assert isinstance(encoding[0], Ragged)
-    numpy.testing.assert_equal(encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 6, 2, 1])
-    numpy.testing.assert_equal(
+    ops = get_current_ops()
+    ops.xp.testing.assert_array_equal(
+        encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 6, 2, 1]
+    )
+    ops.xp.testing.assert_array_equal(
         encoding[0].dataXd,
         [0, 9, 466, 11, 948, 42, 11, 171, 169, 111, 29, 21, 144, 8, 5, 2],
     )
 
     assert isinstance(encoding[1], Ragged)
-    numpy.testing.assert_equal(encoding[1].lengths, [1, 2, 1, 1, 1, 4, 3, 2, 1])
-    numpy.testing.assert_equal(
+    ops.xp.testing.assert_array_equal(encoding[1].lengths, [1, 2, 1, 1, 1, 4, 3, 2, 1])
+    ops.xp.testing.assert_array_equal(
         encoding[1].dataXd,
         [0, 484, 547, 113, 172, 568, 63, 21, 46, 3, 85, 116, 28, 8, 5, 2],
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Tests were using `numpy` specific code to compare tensors, and this resulted in `TypeErrors` when they were executed on the GPU. This PR changes the relevant code to be device-agnostic whenever possible. In instances where this is not possible, GPU tensors are explicitly copied to the host before comparison.

Additionally, the `test_xlmr_transformer_pipe_against_hf` test was modified to use a higher tolerance for tensor comparisons to work around small differences stemming from GPU-related non-determinism.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Bug fix.

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
