### PR TITLE
Add support for Torch `scaled_dot_product_attention`

### DIFF
--- a/curated_transformers/_compat.py
+++ b/curated_transformers/_compat.py
@@ -1,4 +1,10 @@
+from os import environ
 from spacy.lang.ja import try_sudachi_import
+import torch
+
+has_torch_sdp_attention = hasattr(
+    torch.nn.functional, "scaled_dot_product_attention"
+) and environ.get("CURATED_TORCH_SDPA")
 
 try:
     import transformers

--- a/curated_transformers/models/pytorch/bert/layer.py
+++ b/curated_transformers/models/pytorch/bert/layer.py
@@ -72,9 +72,9 @@ class BertSelfAttention(Module):
             mask = attn_mask.bool_mask.view(batch, 1, 1, seq_len)
             # Ignore because we still support torch<2.0.0 and older versions
             # do not have this attribute.
-            attn = torch.nn.functional.scaled_dot_product_attention(
+            attn = torch.nn.functional.scaled_dot_product_attention(  # type: ignore[attr-defined]
                 q, k, v, mask, self.dropout_prob if self.training else 0.0
-            )  # type: ignore[attr-defined]
+            )
         else:
             attn = self.attention(k, q, v, attn_mask)
 

--- a/curated_transformers/models/pytorch/bert/layer.py
+++ b/curated_transformers/models/pytorch/bert/layer.py
@@ -66,7 +66,7 @@ class BertSelfAttention(Module):
         q = self._split_heads(q)
         v = self._split_heads(v)
 
-        # attn: (batch, seq_len, width)
+        # attn: (batch, head, seq_len, with_per_head)
         if has_torch_sdp_attention:
             batch, seq_len = attn_mask.shape
             mask = attn_mask.bool_mask.view(batch, 1, 1, seq_len)
@@ -76,6 +76,7 @@ class BertSelfAttention(Module):
         else:
             attn = self.attention(k, q, v, attn_mask)
 
+        # attn: (batch, seq_len, width)
         attn = self._combine_heads(attn)
 
         out = self.output(attn)

--- a/curated_transformers/models/pytorch/bert/layer.py
+++ b/curated_transformers/models/pytorch/bert/layer.py
@@ -70,9 +70,11 @@ class BertSelfAttention(Module):
         if has_torch_sdp_attention:
             batch, seq_len = attn_mask.shape
             mask = attn_mask.bool_mask.view(batch, 1, 1, seq_len)
+            # Ignore because we still support torch<2.0.0 and older versions
+            # do not have this attribute.
             attn = torch.nn.functional.scaled_dot_product_attention(
                 q, k, v, mask, self.dropout_prob if self.training else 0.0
-            )
+            )  # type: ignore[attr-defined]
         else:
             attn = self.attention(k, q, v, attn_mask)
 

--- a/curated_transformers/models/pytorch/bert/layer.py
+++ b/curated_transformers/models/pytorch/bert/layer.py
@@ -6,6 +6,7 @@ from .. import GeluNew
 from ..attention import AttentionMask, ScaledDotProductAttention
 from .config import BertAttentionConfig, BertLayerConfig
 from ..linear import Linear
+from ...._compat import has_torch_sdp_attention
 from ....errors import Errors
 
 
@@ -14,6 +15,7 @@ class BertSelfAttention(Module):
     def __init__(self, config: BertAttentionConfig):
         super().__init__()
 
+        self.dropout_prob = config.dropout_prob
         self.model_dim = config.hidden_width
         self.num_heads = config.num_attention_heads
         if self.model_dim % self.num_heads != 0:
@@ -56,7 +58,6 @@ class BertSelfAttention(Module):
             x - (batch, seq_len, width)
             attn_mask - (batch, seq_len)
         """
-
         proj = self.input(x)
         q, k, v = proj.chunk(3, dim=-1)
 
@@ -65,8 +66,18 @@ class BertSelfAttention(Module):
         q = self._split_heads(q)
         v = self._split_heads(v)
 
-        # (batch, seq_len, width)
-        attn = self._combine_heads(self.attention(k, q, v, attn_mask))
+        # attn: (batch, seq_len, width)
+        if has_torch_sdp_attention:
+            batch, seq_len = attn_mask.shape
+            mask = attn_mask.bool_mask.view(batch, 1, 1, seq_len)
+            attn = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, mask, self.dropout_prob if self.training else 0.0
+            )
+        else:
+            attn = self.attention(k, q, v, attn_mask)
+
+        attn = self._combine_heads(attn)
+
         out = self.output(attn)
 
         return out

--- a/curated_transformers/tests/models/test_hf_model.py
+++ b/curated_transformers/tests/models/test_hf_model.py
@@ -77,11 +77,11 @@ def test_model_against_hf_transformers(model_config):
     Y_hf_encoder = hf_encoder(X, attention_mask=attention_mask)
 
     assert torch.allclose(
-        Y_encoder.last_hidden_layer_states, Y_hf_encoder.last_hidden_state, atol=1e-6
+        Y_encoder.last_hidden_layer_states, Y_hf_encoder.last_hidden_state, atol=1e-5
     )
 
     # Try to infer the attention mask from padding.
     Y_encoder = encoder(X)
     assert torch.allclose(
-        Y_encoder.last_hidden_layer_states, Y_hf_encoder.last_hidden_state, atol=1e-6
+        Y_encoder.last_hidden_layer_states, Y_hf_encoder.last_hidden_state, atol=1e-5
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Torch now has a function for computing the scaled dot product attention, `scaled_dot_product_attention`. This change adds support for using this function in our self-attention layer. However, since this function is still in beta and at not faster at the moment, we feature-gate it through the `CURATED_TORCH_SDPA=1` environment variable.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Feature

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
