### PR TITLE
RotaryEmbeddings.forward: add support for a positions tensor

### DIFF
--- a/curated_transformers/tests/models/test_embeddings.py
+++ b/curated_transformers/tests/models/test_embeddings.py
@@ -42,6 +42,12 @@ def test_rotary_embeddings_resize(device):
     assert re.cos.shape == (16, 4)
     assert re.sin.shape == (16, 4)
 
+    positions = torch.tensor([[2, 1, 32], [1, 2, 0]], device=device).view([1, 2, 3])
+    X = torch.rand(1, 2, 3, 4, device=device)
+    re(X, positions=positions)
+    assert re.cos.shape == (33, 4)
+    assert re.sin.shape == (33, 4)
+
 
 @pytest.mark.parametrize("device", TORCH_DEVICES)
 def test_rotary_embeddings_small(device):
@@ -62,6 +68,34 @@ def test_rotary_embeddings_small(device):
                         [1.000000, 1.000000, 1.000000, 1.000000],
                         [-0.301169, 0.989950, 1.381773, 1.009950],
                         [-1.325444, 0.979801, 0.493151, 1.019799],
+                    ],
+                ]
+            ],
+            device=device,
+        ),
+    )
+
+
+@pytest.mark.parametrize("device", TORCH_DEVICES)
+def test_rotary_embeddings_positions_small(device):
+    re = RotaryEmbeddings(4).to(device)
+    X = torch.ones(1, 2, 3, 4, device=device)
+    positions = torch.tensor([[2, 1, 0], [1, 2, 0]], device=device).view([1, 2, 3])
+    Y = re(X, positions=positions)
+    torch_assertclose(
+        Y,
+        torch.tensor(
+            [
+                [
+                    [
+                        [-1.325444, 0.979801, 0.493151, 1.019799],
+                        [-0.301169, 0.989950, 1.381773, 1.009950],
+                        [1.000000, 1.000000, 1.000000, 1.000000],
+                    ],
+                    [
+                        [-0.301169, 0.989950, 1.381773, 1.009950],
+                        [-1.325444, 0.979801, 0.493151, 1.019799],
+                        [1.000000, 1.000000, 1.000000, 1.000000],
                     ],
                 ]
             ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

In most generation scenarios, we are only applying the rotary embeddings to new (uncached) positions. So we need a way to specify what the positions of the inputs are to apply the correct rotary embedding. We cannot use a single offset, since different batch items may have different offsets. For instance, when processing two prompts with different lengths:

```
A B C D E
    X Y Z
```

The initial offsets are:

```
0 1 2 3 4
    0 1 2
```

So when generating the next token, we need the offsets `[[5], [3]]`.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Enhancement.

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
