### PR TITLE
Allow more fine-grained control over tokenizer input

### DIFF
--- a/curated_transformers/tests/tokenization/test_chunks.py
+++ b/curated_transformers/tests/tokenization/test_chunks.py
@@ -1,0 +1,71 @@
+from copy import deepcopy
+
+from curated_transformers.tokenization.chunks import (
+    InputChunks,
+    MergedSpecialPieceChunk,
+    SpecialPieceChunk,
+    TextChunk,
+)
+
+
+def test_text_chunk_merge():
+    chunks = InputChunks(
+        [
+            TextChunk(" "),
+            TextChunk("Hello world!"),
+            TextChunk(" "),
+        ]
+    )
+
+    # Ensure that we are not doing accidental modification to the
+    # object itself.
+    chunks_copy = deepcopy(chunks)
+    chunks.merge_text_chunks()
+    assert chunks == chunks_copy
+
+    assert chunks.merge_text_chunks() == [
+        TextChunk(" Hello world! "),
+    ]
+
+
+def test_special_text_special_chunk_merge():
+    chunks = InputChunks(
+        [
+            SpecialPieceChunk("<s>", after=" "),
+            TextChunk("Hello world!"),
+            SpecialPieceChunk("</s>", before=" "),
+        ]
+    )
+
+    # Ensure that we are not doing accidental modification to the
+    # object itself.
+    chunks_copy = deepcopy(chunks)
+    chunks.merge_text_chunks()
+    assert chunks == chunks_copy
+
+    assert chunks.merge_text_chunks() == [
+        MergedSpecialPieceChunk("<s>"),
+        TextChunk(" Hello world! "),
+        MergedSpecialPieceChunk("</s>"),
+    ]
+
+
+def test_special_special_chunk_merge():
+    chunks = InputChunks(
+        [
+            SpecialPieceChunk("<s>", after=" "),
+            SpecialPieceChunk("</s>", before=" "),
+        ]
+    )
+
+    # Ensure that we are not doing accidental modification to the
+    # object itself.
+    chunks_copy = deepcopy(chunks)
+    chunks.merge_text_chunks()
+    assert chunks == chunks_copy
+
+    assert chunks.merge_text_chunks() == [
+        MergedSpecialPieceChunk("<s>"),
+        TextChunk("  "),
+        MergedSpecialPieceChunk("</s>"),
+    ]

--- a/curated_transformers/tokenization/__init__.py
+++ b/curated_transformers/tokenization/__init__.py
@@ -1,6 +1,7 @@
 from .bbpe_tokenizer import ByteBPETokenizer
 from .bert_tokenizer import BertTokenizer
 from .camembert_tokenizer import CamembertTokenizer
+from .chunks import InputChunks, SpecialPieceChunk, TextChunk
 from .gpt_neox_tokenizer import GPTNeoXTokenizer
 from .roberta_tokenizer import RobertaTokenizer
 from .sentencepiece_tokenizer import SentencePieceTokenizer

--- a/curated_transformers/tokenization/_fairseq.py
+++ b/curated_transformers/tokenization/_fairseq.py
@@ -1,7 +1,7 @@
 from typing import Callable, Iterable, List
 
 from .tokenizer import PiecesWithIds, PostEncoder, PreDecoder
-from .util import remove_pieces_from_sequence, add_bos_eos_to_encoding
+from .util import remove_pieces_from_sequence
 
 
 class FAIRSEQ_PIECE_IDS:
@@ -21,36 +21,16 @@ class FairSeqPostEncoder(PostEncoder):
     def __init__(
         self,
         *,
-        bos_piece: str,
-        eos_piece: str,
-        bos_id: int,
-        eos_id: int,
         piece_updater: Callable[[int], int],
     ):
         """Construct a fairseq post-encoder.
 
-        :param bos_piece: The piece used to mark the beginning of a sequence.
-        :param eos_piece: The piece used to mark the end of a sequence.
-        :param bos_id: The piece id used to mark the beginning of a sequence.
-        :param eos_id: The piece id used to mark the end of a sequence.
         :param piece_updater: Function that tranforms a given
             SentencePiece piece identifier to a valid fairseq one.
         """
-        self.bos_piece = bos_piece
-        self.eos_piece = eos_piece
-        self.bos_id = bos_id
-        self.eos_id = eos_id
         self.piece_updater = piece_updater
 
     def __call__(self, pieces_with_ids: PiecesWithIds) -> PiecesWithIds:
-        pieces_with_ids = add_bos_eos_to_encoding(
-            pieces_with_ids,
-            bos_piece=self.bos_piece,
-            eos_piece=self.eos_piece,
-            bos_id=self.bos_id,
-            eos_id=self.eos_id,
-        )
-
         # We need to align the IDs to the original fairseq vocabulary.
         for piece_ids in pieces_with_ids.ids:
             for i in range(len(piece_ids)):

--- a/curated_transformers/tokenization/bbpe_tokenizer.py
+++ b/curated_transformers/tokenization/bbpe_tokenizer.py
@@ -1,6 +1,11 @@
 from typing import Iterable, List
 from curated_tokenizers import ByteBPEProcessor
 
+from curated_transformers.tokenization.chunks import (
+    MergedInputChunks,
+    MergedSpecialPieceChunk,
+)
+
 from .tokenizer import PiecesWithIds, Tokenizer
 
 
@@ -22,22 +27,30 @@ class ByteBPETokenizer(Tokenizer):
     def _decode(self, input: Iterable[Iterable[int]]) -> List[str]:
         return [self.processor.decode_from_ids(ids) for ids in input]
 
-    def _encode(self, input: Iterable[str]) -> PiecesWithIds:
+    def _encode(self, input: Iterable[MergedInputChunks]) -> PiecesWithIds:
         ids = []
         pieces = []
 
-        for text in input:
-            text_ids = []
-            text_pieces = []
+        for seq in input:
+            seq_ids = []
+            seq_pieces = []
 
-            for idx, token in enumerate(text.split(" ")):
-                if idx != 0:
-                    token = " " + token
-                token_ids, token_pieces = self.processor.encode(token)
-                text_ids.extend(token_ids)
-                text_pieces.extend(token_pieces)
+            for chunk in seq:
+                if isinstance(chunk, MergedSpecialPieceChunk):
+                    piece_id = self.processor.piece_id(chunk.piece)
+                    if piece_id is None:
+                        raise ValueError(f"Unknown special piece: {chunk.piece}")
+                    seq_ids.append(piece_id)
+                    seq_pieces.append(chunk.piece)
+                else:
+                    for idx, token in enumerate(chunk.text.split(" ")):
+                        if idx != 0:
+                            token = " " + token
+                        token_ids, token_pieces = self.processor.encode(token)
+                        seq_ids.extend(token_ids)
+                        seq_pieces.extend(token_pieces)
 
-            ids.append(text_ids)
-            pieces.append(text_pieces)
+            ids.append(seq_ids)
+            pieces.append(seq_pieces)
 
         return PiecesWithIds(ids=ids, pieces=pieces)

--- a/curated_transformers/tokenization/camembert_tokenizer.py
+++ b/curated_transformers/tokenization/camembert_tokenizer.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from ._fairseq import FairSeqPostEncoder, FairSeqPreDecoder, FAIRSEQ_PIECE_IDS
 from .sentencepiece_tokenizer import SentencePieceTokenizer
+from .tokenizer import AddBosEosPreEncoder
 from .hf_hub import FromPretrainedHFTokenizer
 
 
@@ -17,24 +18,9 @@ _CAMEMBERT_FAIRSEQ_OFFSET = 4
 class CamembertPostEncoder(FairSeqPostEncoder):
     def __init__(
         self,
-        *,
-        bos_piece: str,
-        eos_piece: str,
-        bos_id: int,
-        eos_id: int,
     ):
-        """Construct a CamemBERT post-encoder.
-
-        :param bos_piece: The piece used to mark the beginning of a sequence.
-        :param eos_piece: The piece used to mark the end of a sequence.
-        :param bos_id: The piece id used to mark the beginning of a sequence.
-        :param eos_id: The piece id used to mark the end of a sequence.
-        """
+        """Construct a CamemBERT post-encoder."""
         super(CamembertPostEncoder, self).__init__(
-            bos_piece=bos_piece,
-            eos_piece=eos_piece,
-            bos_id=bos_id,
-            eos_id=eos_id,
             piece_updater=CamembertPostEncoder._sentencepiece_to_fairseq,
         )
 
@@ -95,12 +81,9 @@ class CamembertTokenizer(SentencePieceTokenizer, FromPretrainedHFTokenizer):
         bos_id = _get_piece_id_or_fail(processor, bos_piece)
         eos_id = _get_piece_id_or_fail(processor, eos_piece)
 
-        self.post_encoder = CamembertPostEncoder(
-            bos_piece=bos_piece,
-            eos_piece=eos_piece,
-            bos_id=bos_id,
-            eos_id=eos_id,
-        )
+        self.pre_encoder = AddBosEosPreEncoder(bos_piece=bos_piece, eos_piece=eos_piece)
+
+        self.post_encoder = CamembertPostEncoder()
 
         self.pre_decoder = CamembertPreDecoder(
             bos_id=bos_id,

--- a/curated_transformers/tokenization/chunks.py
+++ b/curated_transformers/tokenization/chunks.py
@@ -80,7 +80,7 @@ class InputChunks(List[ChunkT]):
                     new_chunks[-1].text += chunk.text  # type: ignore[union-attr]
                 else:
                     new_chunks.append(dataclasses.replace(chunk))
-            else:
+            elif isinstance(chunk, SpecialPieceChunk):
                 if chunk.before:
                     if last_is_text:
                         new_chunks[-1].text += chunk.before  # type: ignore[union-attr]
@@ -89,5 +89,7 @@ class InputChunks(List[ChunkT]):
                 new_chunks.append(MergedSpecialPieceChunk(chunk.piece))
                 if chunk.after:
                     new_chunks.append(TextChunk(chunk.after))
+            else:
+                raise ValueError(f"Unknown chunk type: {type(chunk).__name__}")
 
         return new_chunks

--- a/curated_transformers/tokenization/chunks.py
+++ b/curated_transformers/tokenization/chunks.py
@@ -1,0 +1,94 @@
+from typing import Optional, Union
+from collections import UserList
+import dataclasses
+from dataclasses import dataclass
+
+
+ChunkT = Union["SpecialPieceChunk", "TextChunk"]
+MergedChunkT = Union["MergedSpecialPieceChunk", "TextChunk"]
+
+
+@dataclass
+class MergedSpecialPieceChunk:
+    """
+    A chunk that contains a special piece. This piece is not tokenized, but
+    looked up directly in the vocabulary.
+
+    :param piece:
+        Piece to look up in the vocabulary.
+    """
+
+    piece: str
+
+
+@dataclass
+class SpecialPieceChunk:
+    """
+    A chunk that contains a special piece. This piece is not tokenized, but
+    looked up directly in the vocabulary. Can additionally store strings that
+    should be appended to a text chunk before or prepended to a text chunk
+    after the special piece.
+
+    :param piece:
+        Piece to look up in the vocabulary.
+    :param after:
+        Text to prepend to the succeeding text chunk.
+    :param before:
+        Text to append to the preceding text chunk.
+    """
+
+    piece: str
+    after: Optional[str] = None
+    before: Optional[str] = None
+
+
+@dataclass
+class TextChunk:
+    """
+    A chunk of text that should be tokenized.
+
+    :param text:
+        Text that should be tokenized.
+    """
+
+    text: str
+
+
+class MergedInputChunks(UserList[MergedChunkT]):
+    """
+    A list of chunks in which consecutive text chunks and before/after
+    texts of special piece chunks are merged.
+    """
+
+    pass
+
+
+class InputChunks(UserList[ChunkT]):
+    """
+    A list of chunks.
+    """
+
+    def merge_text_chunks(self) -> MergedInputChunks:
+        """
+        Merge multiple contiguous text chunks and before/after text
+        in special piece chunks.
+        """
+        new_chunks = MergedInputChunks()
+        for chunk in self:
+            last_is_text = new_chunks and isinstance(new_chunks[-1], TextChunk)
+            if isinstance(chunk, TextChunk):
+                if last_is_text:
+                    new_chunks[-1].text += chunk.text  # type: ignore[union-attr]
+                else:
+                    new_chunks.append(dataclasses.replace(chunk))
+            else:
+                if chunk.before:
+                    if last_is_text:
+                        new_chunks[-1].text += chunk.before  # type: ignore[union-attr]
+                    else:
+                        new_chunks.append(TextChunk(chunk.before))
+                new_chunks.append(MergedSpecialPieceChunk(chunk.piece))
+                if chunk.after:
+                    new_chunks.append(TextChunk(chunk.after))
+
+        return new_chunks

--- a/curated_transformers/tokenization/chunks.py
+++ b/curated_transformers/tokenization/chunks.py
@@ -1,5 +1,4 @@
-from typing import Optional, Union
-from collections import UserList
+from typing import List, Optional, Union
 import dataclasses
 from dataclasses import dataclass
 
@@ -54,7 +53,7 @@ class TextChunk:
     text: str
 
 
-class MergedInputChunks(UserList[MergedChunkT]):
+class MergedInputChunks(List[MergedChunkT]):
     """
     A list of chunks in which consecutive text chunks and before/after
     texts of special piece chunks are merged.
@@ -63,7 +62,7 @@ class MergedInputChunks(UserList[MergedChunkT]):
     pass
 
 
-class InputChunks(UserList[ChunkT]):
+class InputChunks(List[ChunkT]):
     """
     A list of chunks.
     """

--- a/curated_transformers/tokenization/gpt_neox_tokenizer.py
+++ b/curated_transformers/tokenization/gpt_neox_tokenizer.py
@@ -39,7 +39,11 @@ class GPTNeoXTokenizer(ByteBPETokenizer, FromPretrainedHFTokenizer):
         deserialized = json.loads(serialized)
         vocab_merges = deserialized["model"]
         merges = [tuple(merge.split(" ")) for merge in vocab_merges["merges"]]
-        processor = ByteBPEProcessor(vocab_merges["vocab"], merges)
+        vocab = vocab_merges["vocab"]
+        for added_token in deserialized["added_tokens"]:
+            vocab[added_token["content"]] = added_token["id"]
+
+        processor = ByteBPEProcessor(vocab, merges)
         return cls(
             processor=processor,
         )

--- a/curated_transformers/tokenization/roberta_tokenizer.py
+++ b/curated_transformers/tokenization/roberta_tokenizer.py
@@ -4,9 +4,10 @@ import json
 from pathlib import Path
 
 from .bbpe_tokenizer import ByteBPETokenizer
+from .chunks import InputChunks, SpecialPieceChunk, TextChunk
 from .hf_hub import FromPretrainedHFTokenizer
-from .tokenizer import PiecesWithIds, PostEncoder, PreDecoder
-from .util import remove_pieces_from_sequence, add_bos_eos_to_encoding
+from .tokenizer import AddBosEosPreEncoder, PreEncoder, PreDecoder
+from .util import remove_pieces_from_sequence
 
 
 # Only provided as typing.Self in Python 3.11+.
@@ -35,37 +36,6 @@ class RobertaPreDecoder(PreDecoder):
         ]
 
 
-class RobertaPostEncoder(PostEncoder):
-    def __init__(
-        self,
-        *,
-        bos_piece: str,
-        eos_piece: str,
-        bos_id: int,
-        eos_id: int,
-    ):
-        """Construct a RoBERTa post-encoder.
-
-        bos_piece (str): The piece used to mark the beginning of a sequence.
-        eos_piece (str): The piece used to mark the end of a sequence.
-        bos_id (int): The piece id used to mark the beginning of a sequence.
-        eos_id (int): The piece id used to mark the end of a sequence.
-        """
-        self.bos_piece = bos_piece
-        self.eos_piece = eos_piece
-        self.bos_id = bos_id
-        self.eos_id = eos_id
-
-    def __call__(self, pieces_with_ids: PiecesWithIds) -> PiecesWithIds:
-        return add_bos_eos_to_encoding(
-            pieces_with_ids,
-            bos_piece=self.bos_piece,
-            eos_piece=self.eos_piece,
-            bos_id=self.bos_id,
-            eos_id=self.eos_id,
-        )
-
-
 class RobertaTokenizer(ByteBPETokenizer, FromPretrainedHFTokenizer):
     def __init__(
         self,
@@ -92,12 +62,7 @@ class RobertaTokenizer(ByteBPETokenizer, FromPretrainedHFTokenizer):
             eos_id=eos_id,
         )
 
-        self.post_encoder = RobertaPostEncoder(
-            bos_piece=bos_piece,
-            eos_piece=eos_piece,
-            bos_id=bos_id,
-            eos_id=eos_id,
-        )
+        self.pre_encoder = AddBosEosPreEncoder(bos_piece=bos_piece, eos_piece=eos_piece)
 
     @classmethod
     def from_files(

--- a/curated_transformers/tokenization/roberta_tokenizer.py
+++ b/curated_transformers/tokenization/roberta_tokenizer.py
@@ -4,9 +4,8 @@ import json
 from pathlib import Path
 
 from .bbpe_tokenizer import ByteBPETokenizer
-from .chunks import InputChunks, SpecialPieceChunk, TextChunk
 from .hf_hub import FromPretrainedHFTokenizer
-from .tokenizer import AddBosEosPreEncoder, PreEncoder, PreDecoder
+from .tokenizer import AddBosEosPreEncoder, PreDecoder
 from .util import remove_pieces_from_sequence
 
 

--- a/curated_transformers/tokenization/sentencepiece_tokenizer.py
+++ b/curated_transformers/tokenization/sentencepiece_tokenizer.py
@@ -1,6 +1,7 @@
 from typing import Iterable, List
 from curated_tokenizers import SentencePieceProcessor
 
+from .chunks import MergedInputChunks, MergedSpecialPieceChunk
 from .tokenizer import PiecesWithIds, Tokenizer
 
 
@@ -22,17 +23,31 @@ class SentencePieceTokenizer(Tokenizer):
     def _decode(self, input: Iterable[Iterable[int]]) -> List[str]:
         return [self.processor.decode_from_ids(ids) for ids in input]
 
-    def _encode(self, input: Iterable[str]) -> PiecesWithIds:
+    def _encode(self, input: Iterable[MergedInputChunks]) -> PiecesWithIds:
         ids = []
         pieces = []
 
-        for text in input:
-            text_lens = []
+        for seq in input:
+            seq_ids = []
+            seq_pieces = []
 
-            text_ids, text_pieces = self.processor.encode(text)
-            text_lens.append(len(text_ids))
+            for chunk in seq:
+                if isinstance(chunk, MergedSpecialPieceChunk):
+                    # TODO: this is not ideal. piece_id() should probably return
+                    # None for unknown pieces.
+                    unk_id = self.processor.unk_id()
+                    unk_piece = self.processor.id_to_piece(unk_id)
+                    piece_id = self.processor.piece_to_id(chunk.piece)
+                    if piece_id == unk_id and chunk.piece != unk_piece:
+                        raise ValueError(f"Unknown special piece: {chunk.piece}")
+                    seq_ids.append(piece_id)
+                    seq_pieces.append(chunk.piece)
+                else:
+                    chunk_ids, chunk_pieces = self.processor.encode(chunk.text)
+                    seq_ids.extend(chunk_ids)
+                    seq_pieces.extend(chunk_pieces)
 
-            ids.append(text_ids)
-            pieces.append(text_pieces)
+            ids.append(seq_ids)
+            pieces.append(seq_pieces)
 
         return PiecesWithIds(ids=ids, pieces=pieces)

--- a/curated_transformers/tokenization/util.py
+++ b/curated_transformers/tokenization/util.py
@@ -7,20 +7,3 @@ def remove_pieces_from_sequence(
     input: Iterable[int], pieces_to_remove: Tuple[int, ...]
 ) -> Iterable[int]:
     return (piece for piece in input if piece not in pieces_to_remove)
-
-
-def add_bos_eos_to_encoding(
-    pieces_with_ids: PiecesWithIds,
-    bos_piece: str,
-    eos_piece: str,
-    bos_id: int,
-    eos_id: int,
-) -> PiecesWithIds:
-    ids = []
-    for seq_ids in pieces_with_ids.ids:
-        ids.append([bos_id] + seq_ids + [eos_id])
-    pieces = []
-    for seq_pieces in pieces_with_ids.pieces:
-        pieces.append([bos_piece] + seq_pieces + [eos_piece])
-
-    return PiecesWithIds(ids=ids, pieces=pieces)

--- a/curated_transformers/tokenization/xlmr_tokenizer.py
+++ b/curated_transformers/tokenization/xlmr_tokenizer.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from ._fairseq import FairSeqPostEncoder, FairSeqPreDecoder, FAIRSEQ_PIECE_IDS
 from .sentencepiece_tokenizer import SentencePieceTokenizer
+from .tokenizer import AddBosEosPreEncoder
 from .hf_hub import FromPretrainedHFTokenizer
 
 
@@ -17,24 +18,11 @@ _XLMR_FAIRSEQ_OFFSET = 1
 class XlmrPostEncoder(FairSeqPostEncoder):
     def __init__(
         self,
-        *,
-        bos_piece: str,
-        eos_piece: str,
-        bos_id: int,
-        eos_id: int,
     ):
-        """Construct a XLM-R post-encoder.
-
-        :param bos_piece: The piece used to mark the beginning of a sequence.
-        :param eos_piece: The piece used to mark the end of a sequence.
-        :param bos_id: The piece id used to mark the beginning of a sequence.
-        :param eos_id: The piece id used to mark the end of a sequence.
+        """
+        Construct a XLM-R post-encoder.
         """
         super(XlmrPostEncoder, self).__init__(
-            bos_piece=bos_piece,
-            eos_piece=eos_piece,
-            bos_id=bos_id,
-            eos_id=eos_id,
             piece_updater=XlmrPostEncoder._sentencepiece_to_fairseq,
         )
 
@@ -103,12 +91,9 @@ class XlmrTokenizer(SentencePieceTokenizer, FromPretrainedHFTokenizer):
         bos_id = _get_piece_id_or_fail(processor, bos_piece)
         eos_id = _get_piece_id_or_fail(processor, eos_piece)
 
-        self.post_encoder = XlmrPostEncoder(
-            bos_piece=bos_piece,
-            eos_piece=eos_piece,
-            bos_id=bos_id,
-            eos_id=eos_id,
-        )
+        self.pre_encoder = AddBosEosPreEncoder(bos_piece=bos_piece, eos_piece=eos_piece)
+
+        self.post_encoder = XlmrPostEncoder()
 
         self.pre_decoder = XlmrPreDecoder(
             bos_id=bos_id,

--- a/docs/source/tokenizers.rst
+++ b/docs/source/tokenizers.rst
@@ -4,16 +4,16 @@ Tokenization
 Tokenizer inputs
 ----------------
 
-Each tokenizer accepts a ``List[str]`` or a ``List[InputChunks]``. In
-most cases passing a list of strings suffices. However passing
-:class:`.InputChunks` can be useful when adding special pieces to the input is
-required.
+Each tokenizer accepts a ``Iterable[str]`` or a ``Iterable[InputChunks]``. In
+most cases, passing a list of strings should suffice. However, passing
+:class:`.InputChunks` can be useful when special pieces need to be added
+to the input.
 
 When the tokenizer is called with a list of strings, each string is
 automatically converted to a :class:`.TextChunk`, which represents a text chunk
 that should be tokenized. The other type of supported chunk is the
 :class:`.SpecialPieceChunk`. The piece stored by this type of chunk is not
-tokenized, but looked up directly.
+tokenized but looked up directly.
 
 .. autoclass:: curated_transformers.tokenization.InputChunks
    :members:

--- a/docs/source/tokenizers.rst
+++ b/docs/source/tokenizers.rst
@@ -1,6 +1,30 @@
 Tokenization
 ============
 
+Tokenizer inputs
+----------------
+
+Each tokenizer accepts a ``List[str]`` or a ``List[InputChunks]``. In
+most cases passing a list of strings suffices. However passing
+:class:`.InputChunks` can be useful when adding special pieces to the input is
+required.
+
+When the tokenizer is called with a list of strings, each string is
+automatically converted to a :class:`.TextChunk`, which represents a text chunk
+that should be tokenized. The other type of supported chunk is the
+:class:`.SpecialPieceChunk`. The piece stored by this type of chunk is not
+tokenized, but looked up directly.
+
+.. autoclass:: curated_transformers.tokenization.InputChunks
+   :members:
+   :show-inheritance:
+
+.. autoclass:: curated_transformers.tokenization.SpecialPieceChunk
+   :members:
+
+.. autoclass:: curated_transformers.tokenization.TextChunk
+   :members:
+
 Pieces
 ------
 
@@ -14,34 +38,55 @@ stored in a special container :class:`.PiecesWithIds`.
 Tokenizers
 ----------
 
+.. autoclass:: curated_transformers.tokenization.Tokenizer
+   :members:
+   :special-members: __call__
+   :show-inheritance:
+
 .. autoclass:: curated_transformers.tokenization.ByteBPETokenizer
    :members:
+   :inherited-members:
+   :special-members: __call__
    :show-inheritance:
 
 .. autoclass:: curated_transformers.tokenization.WordPieceTokenizer
    :members:
+   :inherited-members:
+   :special-members: __call__
    :show-inheritance:
 
 .. autoclass:: curated_transformers.tokenization.SentencePieceTokenizer
    :members:
+   :inherited-members:
+   :special-members: __call__
    :show-inheritance:
 
 .. autoclass:: curated_transformers.tokenization.GPTNeoXTokenizer
    :members:
+   :inherited-members:
+   :special-members: __call__
    :show-inheritance:
 
 .. autoclass:: curated_transformers.tokenization.RobertaTokenizer
    :members:
+   :inherited-members:
+   :special-members: __call__
    :show-inheritance:
 
 .. autoclass:: curated_transformers.tokenization.BertTokenizer
    :members:
+   :inherited-members:
+   :special-members: __call__
    :show-inheritance:
 
 .. autoclass:: curated_transformers.tokenization.CamembertTokenizer
    :members:
+   :inherited-members:
+   :special-members: __call__
    :show-inheritance:
 
 .. autoclass:: curated_transformers.tokenization.XlmrTokenizer
    :members:
+   :inherited-members:
+   :special-members: __call__
    :show-inheritance:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Before this change, tokenizers took `List[str]` is their input. However, this is not ideal in some cases. For instance in many LLMs we have to provide a model with special pieces to signal e.g. the start/end of a prompt. To serve these use cases, this change allows more fine-grained control over the input.

Besides supporting `List[str]`, the tokenizers now also support `List[InputChunks]`. `InputChunks` is a list-derived data structure that can contain one of two types of chunks:

* `TextChunk`: this is a regular piece of text that should be tokenized.
* `SpecialPieceChunk`: this type of chunk stores a single piece that should be looked up in directly in the vocabulary. Additionally, it can have strings to be appended/prepended to the preceding/succeeding text chunks.

The tokenizer normalizes these chunks by merging consecutive text chunks and adding the strings specified in special piece chunks. After this merge step, it processes the chunks.

Since we can have special pieces in the input with this change, begin/end of sequence markers can now be added safely in the pre-encoders.

In order to test the use of special piece chunks in the input, the GPT-NeoX tokenizer is updated to include special pieces in the vocabulary. We may eventually want to do this for other types of tokenizers as well.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Feature

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
