### PR TITLE
Load pre-trained models from HF Hub without unnecessary allocations

### DIFF
--- a/curated_transformers/models/albert/layer_group.py
+++ b/curated_transformers/models/albert/layer_group.py
@@ -1,3 +1,5 @@
+from typing import Optional
+import torch
 from torch import Tensor
 from torch.nn import Module, ModuleList
 
@@ -9,13 +11,17 @@ from .config import AlbertLayerConfig
 
 class AlbertLayerGroup(Module):
     def __init__(
-        self, layer_config: AlbertLayerConfig, attention_config: BertAttentionConfig
+        self,
+        layer_config: AlbertLayerConfig,
+        attention_config: BertAttentionConfig,
+        *,
+        device: Optional[torch.device] = None
     ) -> None:
         super().__init__()
 
         self.group_layers = ModuleList(
             [
-                BertEncoderLayer(layer_config, attention_config)
+                BertEncoderLayer(layer_config, attention_config, device=device)
                 for _ in range(layer_config.inner_group_num)
             ]
         )

--- a/curated_transformers/models/attention.py
+++ b/curated_transformers/models/attention.py
@@ -136,6 +136,7 @@ class SelfAttention(Module):
         dropout_prob: float = 0.1,
         hidden_width: int = 768,
         num_attention_heads: int = 12,
+        device: Optional[torch.device] = None,
     ):
         """Construct a self-attention layer.
 
@@ -143,6 +144,7 @@ class SelfAttention(Module):
             and output layers.
         :param hidden_width: Hidden width of the layer.
         :param num_attention_heads: Number of attention heads.
+        :param device: Device on which the module is to be initialized.
         """
         super().__init__()
 
@@ -155,9 +157,11 @@ class SelfAttention(Module):
             )
 
         self.dims_per_head = self.model_dim // self.num_heads
-        self.attention = ScaledDotProductAttention(dropout_prob=dropout_prob)
-        self.input = Linear(self.model_dim, self.model_dim * 3)
-        self.output = Linear(self.model_dim, self.model_dim)
+        self.attention = ScaledDotProductAttention(
+            dropout_prob=dropout_prob,
+        )
+        self.input = Linear(self.model_dim, self.model_dim * 3, device=device)
+        self.output = Linear(self.model_dim, self.model_dim, device=device)
 
     def forward(
         self,
@@ -213,6 +217,7 @@ class SelfAttentionWithRotaryEmbeddings(Module):
         rotary_fraction: float = 1.0,
         rotary_base: int = 10000,
         split_heads_before_chunk: bool = False,
+        device: Optional[torch.device] = None,
     ):
         """Construct a self-attention layer with rotary position embeddings.
 
@@ -227,6 +232,7 @@ class SelfAttentionWithRotaryEmbeddings(Module):
             into heads before splitting query/key/value representations when
             ``True``. This option is required for some newer transformer
             architectures that split heads before chunking.
+        :param device: Device on which the module is to be initialized.
         """
 
         super().__init__()
@@ -248,10 +254,14 @@ class SelfAttentionWithRotaryEmbeddings(Module):
             )
         self.rotary_dims = int(rotary_fraction * self.dims_per_head)
 
-        self.input = Linear(self.model_dim, self.model_dim * 3)
-        self.attention = ScaledDotProductAttention(dropout_prob=dropout_prob)
-        self.output = Linear(self.model_dim, self.model_dim)
-        self.rotary_embeds = RotaryEmbeddings(width=self.rotary_dims, base=rotary_base)
+        self.input = Linear(self.model_dim, self.model_dim * 3, device=device)
+        self.attention = ScaledDotProductAttention(
+            dropout_prob=dropout_prob,
+        )
+        self.output = Linear(self.model_dim, self.model_dim, device=device)
+        self.rotary_embeds = RotaryEmbeddings(
+            width=self.rotary_dims, base=rotary_base, device=device
+        )
 
     def forward(
         self,

--- a/curated_transformers/models/attention.py
+++ b/curated_transformers/models/attention.py
@@ -333,7 +333,7 @@ class SelfAttentionWithRotaryEmbeddings(Module):
                 positions = torch.arange(
                     cache_len,
                     cache_len + seq_len,
-                    dtype=torch.int32,
+                    dtype=torch.long,  # `torch.int32` isn't supported in indexing operations prior in torch<2.0.0.
                     device=k_rotary.device,
                 ).repeat(x.size(0), 1)
 

--- a/curated_transformers/models/bert/embeddings.py
+++ b/curated_transformers/models/bert/embeddings.py
@@ -8,32 +8,43 @@ from .config import BertEmbeddingConfig, BertLayerConfig
 
 class BertEmbeddings(Module):
     def __init__(
-        self, embedding_config: BertEmbeddingConfig, layer_config: BertLayerConfig
+        self,
+        embedding_config: BertEmbeddingConfig,
+        layer_config: BertLayerConfig,
+        *,
+        device: Optional[torch.device] = None
     ) -> None:
         super().__init__()
 
         self.word_embeddings = Embedding(
             num_embeddings=embedding_config.vocab_size,
             embedding_dim=embedding_config.embedding_width,
+            device=device,
         )
         self.token_type_embeddings = Embedding(
             num_embeddings=embedding_config.type_vocab_size,
             embedding_dim=embedding_config.embedding_width,
+            device=device,
         )
         self.position_embeddings = Embedding(
             num_embeddings=embedding_config.max_position_embeddings,
             embedding_dim=embedding_config.embedding_width,
+            device=device,
         )
 
         if embedding_config.embedding_width != layer_config.hidden_width:
             self.projection = Linear(
-                embedding_config.embedding_width, layer_config.hidden_width
+                embedding_config.embedding_width,
+                layer_config.hidden_width,
+                device=device,
             )
         else:
             self.projection = None  # type: ignore
 
         self.layer_norm = LayerNorm(
-            embedding_config.embedding_width, eps=embedding_config.layer_norm_eps
+            embedding_config.embedding_width,
+            eps=embedding_config.layer_norm_eps,
+            device=device,
         )
         self.dropout = Dropout(p=embedding_config.dropout_prob)
 

--- a/curated_transformers/models/bert/encoder.py
+++ b/curated_transformers/models/bert/encoder.py
@@ -18,18 +18,15 @@ Self = TypeVar("Self", bound="BertEncoder")
 
 
 class BertEncoder(Module, FromPretrainedHFModel):
-    def __init__(
-        self,
-        config: BertConfig,
-    ):
+    def __init__(self, config: BertConfig, *, device: Optional[torch.device] = None):
         super().__init__()
 
-        self.embeddings = BertEmbeddings(config.embedding, config.layer)
+        self.embeddings = BertEmbeddings(config.embedding, config.layer, device=device)
         self.padding_id = config.padding_id
         self.max_seq_len = config.model_max_length
         self.layers = torch.nn.ModuleList(
             [
-                BertEncoderLayer(config.layer, config.attention)
+                BertEncoderLayer(config.layer, config.attention, device=device)
                 for _ in range(config.layer.num_hidden_layers)
             ]
         )
@@ -67,6 +64,11 @@ class BertEncoder(Module, FromPretrainedHFModel):
         return convert_hf_state_dict(params)
 
     @classmethod
-    def from_hf_config(cls: Type[Self], *, hf_config: Any) -> Self:
+    def from_hf_config(
+        cls: Type[Self],
+        *,
+        hf_config: Any,
+        device: Optional[torch.device] = None,
+    ) -> Self:
         config = convert_hf_config(hf_config)
-        return cls(config)
+        return cls(config, device=device)

--- a/curated_transformers/models/bert/layer.py
+++ b/curated_transformers/models/bert/layer.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import torch
 from torch.nn import Linear, Module
 from torch import Tensor
@@ -9,7 +10,11 @@ from ..feedforward import PointwiseFeedForward
 
 class BertEncoderLayer(Module):
     def __init__(
-        self, layer_config: BertLayerConfig, attention_config: BertAttentionConfig
+        self,
+        layer_config: BertLayerConfig,
+        attention_config: BertAttentionConfig,
+        *,
+        device: Optional[torch.device] = None
     ):
         super().__init__()
 
@@ -17,18 +22,20 @@ class BertEncoderLayer(Module):
             dropout_prob=attention_config.dropout_prob,
             hidden_width=attention_config.hidden_width,
             num_attention_heads=attention_config.num_attention_heads,
+            device=device,
         )
         self.attn_output_layernorm = torch.nn.LayerNorm(
-            layer_config.hidden_width, eps=layer_config.layer_norm_eps
+            layer_config.hidden_width, eps=layer_config.layer_norm_eps, device=device
         )
         self.attn_output_dropout = torch.nn.Dropout(p=layer_config.dropout_prob)
         self.ffn = PointwiseFeedForward(
             hidden_act=layer_config.hidden_act,
             hidden_width=layer_config.hidden_width,
             intermediate_width=layer_config.intermediate_width,
+            device=device,
         )
         self.ffn_output_layernorm = torch.nn.LayerNorm(
-            layer_config.hidden_width, eps=layer_config.layer_norm_eps
+            layer_config.hidden_width, eps=layer_config.layer_norm_eps, device=device
         )
         self.ffn_output_dropout = torch.nn.Dropout(p=layer_config.dropout_prob)
 

--- a/curated_transformers/models/embeddings.py
+++ b/curated_transformers/models/embeddings.py
@@ -74,7 +74,7 @@ class RotaryEmbeddings(Module):
 
         # Ignore allocations on the meta device as we don't persist our buffer,
         # i.e., we don't expect the backing tensor to be replaced with pretrained weights.
-        if device.type == "meta":
+        if device is not None and device.type == "meta":
             device = None
         # Θ_i = 10000^(-2(i-1)/d)
         theta = torch.pow(

--- a/curated_transformers/models/embeddings.py
+++ b/curated_transformers/models/embeddings.py
@@ -72,6 +72,10 @@ class RotaryEmbeddings(Module):
         if width % 2:
             raise ValueError(f"Width of rotary embeddings must be even, was: {width}")
 
+        # Ignore allocations on the meta device as we don't persist our buffer,
+        # i.e., we don't expect the backing tensor to be replaced with pretrained weights.
+        if device == torch.device("meta"):
+            device = None
         # Θ_i = 10000^(-2(i-1)/d)
         theta = torch.pow(
             base, -torch.arange(0, width, 2, dtype=torch.float, device=device) / width

--- a/curated_transformers/models/embeddings.py
+++ b/curated_transformers/models/embeddings.py
@@ -7,13 +7,22 @@ from torch.nn import Module
 
 # https://pytorch.org/tutorials/beginner/transformer_tutorial.html
 class SinusoidalPositionalEmbedding(Module):
-    def __init__(self, dim: int, max_len: int, *, normalize=True):
+    def __init__(
+        self,
+        dim: int,
+        max_len: int,
+        *,
+        normalize=True,
+        device: Optional[torch.device] = None,
+    ):
         super().__init__()
 
-        position = torch.arange(max_len).unsqueeze(1)
-        div_term = torch.exp(torch.arange(0, dim, 2) * (-math.log(10000.0) / dim))
+        position = torch.arange(max_len, device=device).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, dim, 2, device=device) * (-math.log(10000.0) / dim)
+        )
 
-        pe = torch.zeros(max_len, dim)
+        pe = torch.zeros(max_len, dim, device=device)
         pe[:, 0::2] = torch.sin(position * div_term)
         pe[:, 1::2] = torch.cos(position * div_term)
 
@@ -37,7 +46,14 @@ class RotaryEmbeddings(Module):
     sin: Tensor
     theta: Tensor
 
-    def __init__(self, width: int, *, seq_len: int = 512, base: int = 10000):
+    def __init__(
+        self,
+        width: int,
+        *,
+        seq_len: int = 512,
+        base: int = 10000,
+        device: Optional[torch.device] = None,
+    ):
         """Rotary embeddings (Su et al., 2021) layer. The rotary embedding
         will be precomputed for up to 'seq _len' positions. The embedding
         will be recomputed when a longer sequence is found in the input.
@@ -48,14 +64,18 @@ class RotaryEmbeddings(Module):
             Number of positons to initially precompute.
         :param base:
             The base used for Θ_i, determines the cycle length of the
-            embeddings."""
+            embeddings.
+        :param device: Device on which the module is to be initialized.
+        """
         super().__init__()
 
         if width % 2:
             raise ValueError(f"Width of rotary embeddings must be even, was: {width}")
 
         # Θ_i = 10000^(-2(i-1)/d)
-        theta = torch.pow(base, -torch.arange(0, width, 2, dtype=torch.float) / width)
+        theta = torch.pow(
+            base, -torch.arange(0, width, 2, dtype=torch.float, device=device) / width
+        )
         self.register_buffer("theta", theta, persistent=False)
 
         self._create_rotary_embed(width=width, length=seq_len)

--- a/curated_transformers/models/embeddings.py
+++ b/curated_transformers/models/embeddings.py
@@ -74,7 +74,7 @@ class RotaryEmbeddings(Module):
 
         # Ignore allocations on the meta device as we don't persist our buffer,
         # i.e., we don't expect the backing tensor to be replaced with pretrained weights.
-        if device == torch.device("meta"):
+        if device.type == "meta":
             device = None
         # Θ_i = 10000^(-2(i-1)/d)
         theta = torch.pow(

--- a/curated_transformers/models/feedforward.py
+++ b/curated_transformers/models/feedforward.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import torch
 from torch import Tensor
 from torch.nn import Linear, Module
@@ -29,11 +30,12 @@ class PointwiseFeedForward(Module):
         hidden_act: str = "gelu",
         hidden_width: int = 768,
         intermediate_width: int = 3072,
+        device: Optional[torch.device] = None,
     ):
         super().__init__()
 
-        self.intermediate = Linear(hidden_width, intermediate_width)
-        self.output = Linear(intermediate_width, hidden_width)
+        self.intermediate = Linear(hidden_width, intermediate_width, device=device)
+        self.output = Linear(intermediate_width, hidden_width, device=device)
         if hidden_act == "relu":
             self.activation = torch.nn.ReLU()  # type: ignore
         elif hidden_act == "gelu":

--- a/curated_transformers/models/gpt_neox/causal_lm.py
+++ b/curated_transformers/models/gpt_neox/causal_lm.py
@@ -1,4 +1,5 @@
 from typing import Any, List, Mapping, Optional, Type, TypeVar
+import torch
 from torch import Tensor
 from torch.nn import Linear, Parameter
 
@@ -18,17 +19,21 @@ Self = TypeVar("Self", bound="GPTNeoXCausalLM")
 class GPTNeoXCausalLM(CausalLMModule, FromPretrainedHFModel):
     """GPT-NeoX (Black et al, 2022) causal language model."""
 
-    def __init__(self, config: GPTNeoXConfig) -> None:
+    def __init__(
+        self, config: GPTNeoXConfig, *, device: Optional[torch.device] = None
+    ) -> None:
         """
         :param config: Model configuration.
+        :param device: Device on which the module is to be initialized.
         """
         super().__init__()
 
-        self.decoder = GPTNeoXDecoder(config)
+        self.decoder = GPTNeoXDecoder(config, device=device)
         self.output_embeddings = Linear(
             in_features=config.layer.hidden_width,
             out_features=config.embedding.vocab_size,
             bias=False,
+            device=device,
         )
 
     def forward(
@@ -81,6 +86,11 @@ class GPTNeoXCausalLM(CausalLMModule, FromPretrainedHFModel):
         return convert_hf_state_dict(cls, params)
 
     @classmethod
-    def from_hf_config(cls: Type[Self], *, hf_config: Any) -> Self:
+    def from_hf_config(
+        cls: Type[Self],
+        *,
+        hf_config: Any,
+        device: Optional[torch.device] = None,
+    ) -> Self:
         config = convert_hf_config(hf_config)
-        return cls(config)
+        return cls(config, device=device)

--- a/curated_transformers/models/gpt_neox/layer.py
+++ b/curated_transformers/models/gpt_neox/layer.py
@@ -16,11 +16,16 @@ class GPTNeoXDecoderLayer(Module):
     """GPT-NeoX (Black et al, 2022) layer."""
 
     def __init__(
-        self, layer_config: GPTNeoXLayerConfig, attention_config: GPTNeoXAttentionConfig
+        self,
+        layer_config: GPTNeoXLayerConfig,
+        attention_config: GPTNeoXAttentionConfig,
+        *,
+        device: Optional[torch.device] = None
     ):
         """
         :param layer_config: Layer configuration.
         :param attention_config: Attention configuration.
+        :param device: Device on which the module is to be initialized.
         """
         super().__init__()
 
@@ -31,19 +36,21 @@ class GPTNeoXDecoderLayer(Module):
             rotary_fraction=attention_config.rotary_fraction,
             rotary_base=attention_config.rotary_base,
             split_heads_before_chunk=True,
+            device=device,
         )
         self.attn_output_dropout = torch.nn.Dropout(p=layer_config.dropout_prob)
         self.mha_layer_norm = torch.nn.LayerNorm(
-            layer_config.hidden_width, eps=layer_config.layer_norm_eps
+            layer_config.hidden_width, eps=layer_config.layer_norm_eps, device=device
         )
 
         self.ffn = PointwiseFeedForward(
             hidden_act=layer_config.hidden_act,
             hidden_width=layer_config.hidden_width,
             intermediate_width=layer_config.intermediate_width,
+            device=device,
         )
         self.ffn_layer_norm = torch.nn.LayerNorm(
-            layer_config.hidden_width, eps=layer_config.layer_norm_eps
+            layer_config.hidden_width, eps=layer_config.layer_norm_eps, device=device
         )
         self.ffn_output_dropout = torch.nn.Dropout(p=layer_config.dropout_prob)
 

--- a/curated_transformers/models/hf_hub.py
+++ b/curated_transformers/models/hf_hub.py
@@ -85,6 +85,10 @@ class FromPretrainedHFModel(ABC):
         state_dict = cls.convert_hf_state_dict(state_dict)
 
         emplace_module_state_dict(model, state_dict, device=device)  # type:ignore
+        # Ensure that any non-persistent buffers are also moved to
+        # the correct device.
+        if device is not None:
+            model.to(device)
 
         return model
 

--- a/curated_transformers/models/hf_hub.py
+++ b/curated_transformers/models/hf_hub.py
@@ -92,6 +92,21 @@ class FromPretrainedHFModel(ABC):
 
         return model
 
+    @abstractmethod
+    def to(
+        self,
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
+        non_blocking: bool = False,
+    ):
+        """Moves and/or casts the parameters and buffers.
+
+        This method is automatically implemented by also deriving from
+        `torch.nn.Module`. This mixin does not derive from `Module` in
+        order to be an abstract base class.
+        """
+        ...
+
 
 def _get_model_config_filepath(name: str, revision: str) -> str:
     try:

--- a/curated_transformers/models/hf_hub.py
+++ b/curated_transformers/models/hf_hub.py
@@ -79,6 +79,14 @@ class FromPretrainedHFModel(ABC):
         # Initialize the model on the torch `meta` device to avoid unnecessary allocations.
         model = cls.from_hf_config(hf_config=config, device=torch.device("meta"))
 
+        # Convert the model to the expected dtype.
+        dtype_str = config.get("torch_dtype")
+        if dtype_str is not None:
+            dtype = getattr(torch, dtype_str, None)
+            if dtype is None or not isinstance(dtype, torch.dtype):
+                raise ValueError(f"Invalid torch dtype `{dtype_str}`")
+            model.to(dtype=dtype)
+
         # Download model and convert HF parameter names to ours.
         checkpoint_filenames = _get_model_checkpoint_filepaths(name, revision)
         state_dict = _load_state_dict_checkpoints(checkpoint_filenames)

--- a/curated_transformers/models/hf_hub.py
+++ b/curated_transformers/models/hf_hub.py
@@ -7,6 +7,9 @@ import torch
 from torch import Tensor
 from torch.nn import Parameter
 
+from .loading_util import emplace_module_state_dict
+
+
 HF_MODEL_CONFIG = "config.json"
 HF_MODEL_CHECKPOINT = "pytorch_model.bin"
 HF_MODEL_SHARDED_CHECKPOINT_INDEX = "pytorch_model.bin.index.json"
@@ -81,21 +84,9 @@ class FromPretrainedHFModel(ABC):
         state_dict = _load_state_dict_checkpoints(checkpoint_filenames)
         state_dict = cls.convert_hf_state_dict(state_dict)
 
-        model.load_state_dict(state_dict)
-        if device is not None:
-            model.to(device)
+        emplace_module_state_dict(model, state_dict, device=device)  # type:ignore
 
         return model
-
-    @abstractmethod
-    def load_state_dict(self, state_dict: Mapping[str, Any], strict: bool = True):
-        """Load a state dictionary.
-
-        This method is automatically implemented by also deriving from
-        `torch.nn.Module`. This mixin does not derive from `Module` in
-        order to be an abstract base class.
-        """
-        ...
 
 
 def _get_model_config_filepath(name: str, revision: str) -> str:

--- a/curated_transformers/models/loading_util.py
+++ b/curated_transformers/models/loading_util.py
@@ -1,0 +1,105 @@
+import itertools
+from typing import Mapping, Optional
+import torch
+from torch.nn import Module, Parameter
+
+
+def _emplace_module_tensor(
+    module: Module,
+    tensor_name: str,
+    tensor: torch.Tensor,
+    device: Optional[torch.device] = None,
+):
+    """Replaces a module's parameter or (persistent) buffer with the passed tensor and moves it
+    to the given device. This is a zero-copy operation (excluding D2H/H2D transfers) where the
+    input tensor is directly associated with the module. Unexpected behaviour can occur if the same
+    tensor is associated with multiple modules.
+
+    :param module: Module whose associated tensor needs replacing.
+    :param tensor_name: Name of the tensor to be replaced.
+    :param tensor: eplacement tensor.
+    :param device: Device to which the replacement tensor is moved.
+    """
+    is_parameter = tensor_name in module._parameters
+    is_buffer = tensor_name in module._buffers
+    assert is_parameter ^ is_buffer
+
+    if device is not None:
+        tensor = tensor.to(device=device)
+
+    size_mismatch_msg = (
+        "Expected the size of the replacement for `{}` to be {}, but got {}"
+    )
+
+    if is_parameter:
+        old_param = module._parameters[tensor_name]
+        assert old_param is not None
+        if old_param.shape != tensor.shape:
+            raise ValueError(
+                size_mismatch_msg.format(tensor_name, old_param.shape, tensor.shape)
+            )
+        new_param = Parameter(tensor, requires_grad=old_param.requires_grad)
+        module._parameters[tensor_name] = new_param
+    else:
+        old_buffer = module._buffers[tensor_name]
+        assert old_buffer is not None
+        if old_buffer.shape != tensor.shape:
+            raise ValueError(
+                size_mismatch_msg.format(tensor_name, old_buffer.shape, tensor.shape)
+            )
+        module._buffers[tensor_name] = tensor
+
+
+def emplace_module_state_dict(
+    module: Module,
+    state_dict: Mapping[str, torch.Tensor],
+    *,
+    device: Optional[torch.device] = None,
+):
+    """Recursively replace a module's parameters and buffers with the tensors in the given
+    `state_dict` without performing any unnecessary copies.
+
+    :param module: Top-level module whose child tensors needs replacing.
+    :param state_dict: State dictionary containing the replacement tensors
+        and their names.
+    :param device: Device to which the replacement tensors are moved.
+    """
+
+    def emplace(module: Module, state_dict: Mapping[str, torch.Tensor], prefix: str):
+        persistent_buffers = {
+            k: v
+            for k, v in module._buffers.items()
+            if k not in module._non_persistent_buffers_set
+        }
+        local_name_params = itertools.chain(
+            module._parameters.items(), persistent_buffers.items()
+        )
+
+        for name, param in local_name_params:
+            key = prefix + name
+            if param is None:
+                if key in state_dict:
+                    raise ValueError(
+                        f"Key `{name}` found in state dict but no data in module `{prefix}`"
+                    )
+                else:
+                    continue
+            if key not in state_dict:
+                raise ValueError(f"Key `{name}` not found in module `{prefix}`")
+            replacement = state_dict[key]
+            _emplace_module_tensor(module, name, replacement, device=device)
+
+    def traverse(module: Module, state_dict: Mapping[str, torch.Tensor], prefix: str):
+        emplace(module, state_dict, prefix)
+
+        for name, child in module._modules.items():
+            if child is not None:
+                child_prefix = prefix + name + "."
+                child_state_dict = {
+                    k: v for k, v in state_dict.items() if k.startswith(child_prefix)
+                }
+                traverse(child, child_state_dict, child_prefix)
+
+    traverse(module, state_dict, "")
+    del traverse
+    del emplace

--- a/curated_transformers/models/loading_util.py
+++ b/curated_transformers/models/loading_util.py
@@ -94,7 +94,7 @@ def emplace_module_state_dict(
 
         for name, child in module._modules.items():
             if child is not None:
-                child_prefix = prefix + name + "."
+                child_prefix = f"{prefix}{name}."
                 child_state_dict = {
                     k: v for k, v in state_dict.items() if k.startswith(child_prefix)
                 }

--- a/curated_transformers/models/roberta/embeddings.py
+++ b/curated_transformers/models/roberta/embeddings.py
@@ -1,4 +1,5 @@
 from typing import Optional
+import torch
 from torch.nn import Module
 from torch import Tensor
 
@@ -11,11 +12,12 @@ class RobertaEmbeddings(Module):
         embedding_config: BertEmbeddingConfig,
         layer_config: BertLayerConfig,
         *,
-        padding_id: int
+        padding_id: int,
+        device: Optional[torch.device] = None
     ) -> None:
         super().__init__()
 
-        self.inner = BertEmbeddings(embedding_config, layer_config)
+        self.inner = BertEmbeddings(embedding_config, layer_config, device=device)
         self.padding_id = padding_id
 
     def _get_position_ids(self, x: Tensor) -> Tensor:

--- a/curated_transformers/models/roberta/encoder.py
+++ b/curated_transformers/models/roberta/encoder.py
@@ -20,17 +20,17 @@ Self = TypeVar("Self", bound="RobertaEncoder")
 class RobertaEncoder(EncoderModule, FromPretrainedHFModel):
     """RoBERTa encoder (Liu et al., 2019)"""
 
-    def __init__(self, config: RobertaConfig):
+    def __init__(self, config: RobertaConfig, *, device: Optional[torch.device] = None):
         super().__init__()
 
         self.embeddings = RobertaEmbeddings(
-            config.embedding, config.layer, padding_id=config.padding_id
+            config.embedding, config.layer, padding_id=config.padding_id, device=device
         )
         self.padding_id = config.padding_id
         self.max_seq_len = config.model_max_length
         self.layers = torch.nn.ModuleList(
             [
-                BertEncoderLayer(config.layer, config.attention)
+                BertEncoderLayer(config.layer, config.attention, device=device)
                 for _ in range(config.layer.num_hidden_layers)
             ]
         )
@@ -68,6 +68,11 @@ class RobertaEncoder(EncoderModule, FromPretrainedHFModel):
         return convert_hf_state_dict(params)
 
     @classmethod
-    def from_hf_config(cls: Type[Self], *, hf_config: Any) -> Self:
+    def from_hf_config(
+        cls: Type[Self],
+        *,
+        hf_config: Any,
+        device: Optional[torch.device] = None,
+    ) -> Self:
         config = convert_hf_config(hf_config)
-        return cls(config)
+        return cls(config, device=device)

--- a/curated_transformers/models/scalar_weight.py
+++ b/curated_transformers/models/scalar_weight.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import torch
 from torch import Tensor
 from torch.nn import Module
@@ -6,11 +7,19 @@ from torch.nn import Module
 # From syntaxdot:
 # https://github.com/tensordot/syntaxdot/blob/22bd3d43ed2d7fcbef8a6217b01684194fae713f/syntaxdot-transformers/src/scalar_weighting.rs#L62
 class ScalarWeight(Module):
-    def __init__(self, *, num_layers: int, dropout_prob: float = 0.1):
+    def __init__(
+        self,
+        *,
+        num_layers: int,
+        dropout_prob: float = 0.1,
+        device: Optional[torch.device] = None,
+    ):
         super().__init__()
 
-        self.layer_weights = torch.nn.parameter.Parameter(torch.zeros(num_layers))
-        self.scale = torch.nn.parameter.Parameter(torch.tensor((1.0,)))
+        self.layer_weights = torch.nn.parameter.Parameter(
+            torch.zeros(num_layers, device=device)
+        )
+        self.scale = torch.nn.parameter.Parameter(torch.tensor((1.0,), device=device))
         self.dropout_prob = dropout_prob
 
     def forward(

--- a/curated_transformers/tests/enable_gpu.py
+++ b/curated_transformers/tests/enable_gpu.py
@@ -2,4 +2,4 @@ import torch
 
 from .conftest import TORCH_DEVICES
 
-TORCH_DEVICES.append(torch.device("cuda"))
+TORCH_DEVICES.append(torch.device("cuda", index=0))

--- a/curated_transformers/tests/models/gpt_neox/test_causal_lm.py
+++ b/curated_transformers/tests/models/gpt_neox/test_causal_lm.py
@@ -5,21 +5,25 @@ from curated_transformers._compat import has_hf_transformers, transformers
 from curated_transformers.models.gpt_neox.causal_lm import GPTNeoXCausalLM
 from curated_transformers.tests.util import torch_assertclose
 
+from ...conftest import TORCH_DEVICES
+
 
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
-def test_causal_lm_against_hf():
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_causal_lm_against_hf(torch_device):
     hf_model = transformers.AutoModelForCausalLM.from_pretrained(
         "trl-internal-testing/tiny-random-GPTNeoXForCausalLM"
     )
     hf_model.eval()
+    hf_model.to(torch_device)
 
     model = GPTNeoXCausalLM.from_hf_hub(
-        "trl-internal-testing/tiny-random-GPTNeoXForCausalLM"
+        "trl-internal-testing/tiny-random-GPTNeoXForCausalLM", device=torch_device
     )
     model.eval()
 
     torch.manual_seed(0)
-    X = torch.randint(0, hf_model.config.vocab_size, (2, 10))
+    X = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)
 
     with torch.no_grad():
         Y = model(X).logits

--- a/curated_transformers/tests/models/gpt_neox/test_decoder.py
+++ b/curated_transformers/tests/models/gpt_neox/test_decoder.py
@@ -5,21 +5,25 @@ from curated_transformers._compat import has_hf_transformers, transformers
 from curated_transformers.models.gpt_neox.decoder import GPTNeoXDecoder
 from curated_transformers.tests.util import torch_assertclose
 
+from ...conftest import TORCH_DEVICES
+
 
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
-def test_decoder():
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_decoder(torch_device):
     hf_model = transformers.AutoModel.from_pretrained(
         "trl-internal-testing/tiny-random-GPTNeoXForCausalLM"
     )
+    hf_model.to(torch_device)
     hf_model.eval()
 
     model = GPTNeoXDecoder.from_hf_hub(
-        "trl-internal-testing/tiny-random-GPTNeoXForCausalLM"
+        "trl-internal-testing/tiny-random-GPTNeoXForCausalLM", device=torch_device
     )
     model.eval()
 
     torch.manual_seed(0)
-    X = torch.randint(0, hf_model.config.vocab_size, (2, 10))
+    X = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)
 
     with torch.no_grad():
         Y = model(X).last_hidden_layer_states
@@ -29,20 +33,22 @@ def test_decoder():
 
 
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
-def test_decoder_with_cache():
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_decoder_with_cache(torch_device):
     hf_model = transformers.AutoModel.from_pretrained(
         "trl-internal-testing/tiny-random-GPTNeoXForCausalLM"
     )
+    hf_model.to(torch_device)
     hf_model.eval()
 
     model = GPTNeoXDecoder.from_hf_hub(
-        "trl-internal-testing/tiny-random-GPTNeoXForCausalLM"
+        "trl-internal-testing/tiny-random-GPTNeoXForCausalLM", device=torch_device
     )
     model.eval()
 
     torch.manual_seed(0)
-    X = torch.randint(0, hf_model.config.vocab_size, (2, 10))
-    X_rest = torch.randint(0, hf_model.config.vocab_size, (2, 10))
+    X = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)
+    X_rest = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)
 
     with torch.no_grad():
         Y = model(X, store_cache=True)
@@ -54,20 +60,24 @@ def test_decoder_with_cache():
 
 
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
-def test_decoder_with_positions():
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_decoder_with_positions(torch_device):
     hf_model = transformers.AutoModel.from_pretrained(
         "trl-internal-testing/tiny-random-GPTNeoXForCausalLM"
     )
+    hf_model.to(torch_device)
     hf_model.eval()
 
     model = GPTNeoXDecoder.from_hf_hub(
-        "trl-internal-testing/tiny-random-GPTNeoXForCausalLM"
+        "trl-internal-testing/tiny-random-GPTNeoXForCausalLM", device=torch_device
     )
     model.eval()
 
     torch.manual_seed(0)
-    X = torch.randint(0, hf_model.config.vocab_size, (2, 10))
-    positions = torch.randint(0, hf_model.config.max_position_embeddings, (2, 10))
+    X = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)
+    positions = torch.randint(
+        0, hf_model.config.max_position_embeddings, (2, 10), device=torch_device
+    )
 
     with torch.no_grad():
         Y = model(X, positions=positions).last_hidden_layer_states

--- a/curated_transformers/tests/models/util.py
+++ b/curated_transformers/tests/models/util.py
@@ -16,15 +16,15 @@ def assert_encoder_output_equals_hf(
     atol=1e-5,
     rtol=1e-5
 ):
-    hf_model = transformers.AutoModel.from_pretrained(model_name)
-    hf_model.to(torch_device)
-    hf_model.eval()
-
     model = model_class.from_hf_hub(model_name, device=torch_device)
     model.eval()
 
-    for _, param in model.state_dict():
+    for _, param in model.state_dict().items():
         assert param.device == torch_device
+
+    hf_model = transformers.AutoModel.from_pretrained(model_name)
+    hf_model.to(torch_device)
+    hf_model.eval()
 
     torch.manual_seed(0)
     X = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)

--- a/curated_transformers/tests/models/util.py
+++ b/curated_transformers/tests/models/util.py
@@ -20,9 +20,11 @@ def assert_encoder_output_equals_hf(
     hf_model.to(torch_device)
     hf_model.eval()
 
-    model = model_class.from_hf_hub(model_name)
-    model.to(torch_device)
+    model = model_class.from_hf_hub(model_name, device=torch_device)
     model.eval()
+
+    for _, param in model.state_dict():
+        assert param.device == torch_device
 
     torch.manual_seed(0)
     X = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)


### PR DESCRIPTION
## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
This PR prevents the default initialization of models whose parameters will be replaced with those from HuggingFace Hub immediately. Furthermore, the loading of the serialized weights is performed in a zero-copy fashion when possible.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Enhancement

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.