### PR TITLE
`StringGenerator`: decode all output ids at once

### DIFF
--- a/curated_transformers/generation/dolly_v2.py
+++ b/curated_transformers/generation/dolly_v2.py
@@ -49,11 +49,11 @@ class DollyV2Generator(GeneratorWrapper, FromHFHub):
         )
         return cls(tokenizer, causal_lm)
 
-    def generate(self, prompts: List[str]) -> Iterator[List[Tuple[int, str]]]:
+    def generate(self, prompts: List[str]) -> List[str]:
         prompts_with_instructions = [
             _to_prompt_with_instructions(prompt) for prompt in prompts
         ]
-        yield from self.generator(prompts_with_instructions, eos_id=self.eos_id)
+        return self.generator(prompts_with_instructions, eos_id=self.eos_id)
 
 
 def _to_prompt_with_instructions(prompt):

--- a/curated_transformers/generation/generator_wrapper.py
+++ b/curated_transformers/generation/generator_wrapper.py
@@ -8,7 +8,7 @@ class GeneratorWrapper(ABC):
     :class:`curated_transformers.generation.Generator`.
     """
 
-    def __call__(self, prompts: List[str]) -> Iterator[List[Tuple[int, str]]]:
+    def __call__(self, prompts: List[str]) -> List[str]:
         """
         See the :meth:`.generate` method.
         """
@@ -16,17 +16,14 @@ class GeneratorWrapper(ABC):
         return self.generate(prompts)
 
     @abstractmethod
-    def generate(self, prompts: List[str]) -> Iterator[List[Tuple[int, str]]]:
+    def generate(self, prompts: List[str]) -> List[str]:
         """
-        Generate text using the given prompts. This function yields for
-        each generation step a list of requence identifiers and the
-        corresponding generated substring.
+        Generate text using the given prompts. This method returns the
+        generated text for each prompt.
 
         :param prompts:
             Prompts to generate from.
         :returns:
-            An iterator returning for each generation step sequence
-            identifiers and the substrings that were generated
-            for the sequences.
+            Strings generated for the prompts.
         """
         ...

--- a/curated_transformers/tests/generation/test_dolly_v2.py
+++ b/curated_transformers/tests/generation/test_dolly_v2.py
@@ -1,19 +1,9 @@
-from typing import Iterator, List, Tuple
 import pytest
 import torch
 
 from curated_transformers.generation.dolly_v2 import DollyV2Generator
 
 from ..conftest import GPU_TESTS_ENABLED
-
-
-def _collect_pieces(generator: Iterator[List[Tuple[int, str]]], n: int) -> List[str]:
-    pieces = [[] for _ in range(n)]
-    for step_pieces in generator:
-        for seq_id, piece in step_pieces:
-            pieces[seq_id].append(piece)
-
-    return ["".join(answer) for answer in pieces]
 
 
 @pytest.mark.veryslow
@@ -27,7 +17,8 @@ def test_generate_deterministic():
         "What is the Rust programming language?",
         "What is spaCy?",
     ]
-    assert _collect_pieces(generator(prompts), len(prompts)) == [
+    print(generator(prompts))
+    assert generator(prompts) == [
         "Rust is a multi-paradigm, high-level, general-purpose programming language. Rust is designed to have a small, stable, and fast implementation. Rust is also designed to be easy to learn. Rust is intended to be used for writing fast, reliable, and portable code.\n\n",
         "SpaCy is an open-source natural language processing (NLP) library for Python. It is designed to be fast, scalable, and easy to use.\n\n",
     ]
@@ -36,7 +27,8 @@ def test_generate_deterministic():
         "What is spaCy?",
         "What is the Rust programming language?",
     ]
-    assert _collect_pieces(generator(prompts), len(prompts)) == [
+    print(generator(prompts))
+    assert generator(prompts) == [
         "SpaCy is an open-source natural language processing (NLP) library for Python. It is designed to be fast, scalable, and easy to use.\n\n",
         "Rust is a multi-paradigm, high-level, general-purpose programming language. Rust is designed to have a small, stable, and fast implementation. Rust is also designed to be easy to learn. Rust is intended to be used for writing fast, reliable, and portable code.\n\n",
     ]

--- a/curated_transformers/tests/generation/test_dolly_v2.py
+++ b/curated_transformers/tests/generation/test_dolly_v2.py
@@ -17,7 +17,6 @@ def test_generate_deterministic():
         "What is the Rust programming language?",
         "What is spaCy?",
     ]
-    print(generator(prompts))
     assert generator(prompts) == [
         "Rust is a multi-paradigm, high-level, general-purpose programming language. Rust is designed to have a small, stable, and fast implementation. Rust is also designed to be easy to learn. Rust is intended to be used for writing fast, reliable, and portable code.\n\n",
         "SpaCy is an open-source natural language processing (NLP) library for Python. It is designed to be fast, scalable, and easy to use.\n\n",
@@ -27,7 +26,6 @@ def test_generate_deterministic():
         "What is spaCy?",
         "What is the Rust programming language?",
     ]
-    print(generator(prompts))
     assert generator(prompts) == [
         "SpaCy is an open-source natural language processing (NLP) library for Python. It is designed to be fast, scalable, and easy to use.\n\n",
         "Rust is a multi-paradigm, high-level, general-purpose programming language. Rust is designed to have a small, stable, and fast implementation. Rust is also designed to be easy to learn. Rust is intended to be used for writing fast, reliable, and portable code.\n\n",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

`Generator` returns an iterator, allowing the piece identifiers to be generated incrementally. Similarly, `StringGenerator` also returned an iterator, converting the piece identifiers to pieces. However, the string decoding used for this can fail since not every piece identifier represents a valid UTF-8 string by itself. For example, the byte BPE encoder uses bytes as the smallest unit, and a single byte can represent a UTF-8 initial or continuation byte. Attempting to convert such a byte to a string will be invalid.

Another issue is that potential decoding pre/post-processors may expect to see the full sequence.

This change addresses this shortcoming by accumulating the piece identifiers in `StringGenerator` and only decoding the piece identifiers once all sequences are done generating.

We might want to bring back incremental string generation in the future, but we need to extend the tokenizers to support this properly.


### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bugfix

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
