### PR TITLE
Implement `bitsandbytes` 4-bit and 8-bit quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ change in incompatible ways.
 ```bash
 pip install curated-transformers
 ```
+
+## Quantization
+
+`curated-transformers` implements dynamic 8-bit and 4-bit quantization of models by leveraging the [`bitsandbytes` library](https://github.com/TimDettmers/bitsandbytes).
+
+### Installation
+
+Since `curated-transformers` requires functionality that isn't currently present in `bitsandbytes` (as of `v0.39.0`), one needs to install the library
+from source by cloning the [following branch](https://github.com/shadeMe/bitsandbytes/tree/linear-layer-device) of our fork. Installation instructions
+can be found [here](https://github.com/shadeMe/bitsandbytes/blob/linear-layer-device/compile_from_source.md).

--- a/curated_transformers/_compat.py
+++ b/curated_transformers/_compat.py
@@ -5,3 +5,11 @@ try:
 except ImportError:
     transformers = None  # type: ignore
     has_hf_transformers = False
+
+try:
+    import bitsandbytes
+
+    has_bitsandbytes = True
+except ImportError:
+    bitsandbytes = None  # type: ignore
+    has_bitsandbytes = False

--- a/curated_transformers/_compat.py
+++ b/curated_transformers/_compat.py
@@ -10,6 +10,15 @@ try:
     import bitsandbytes
 
     has_bitsandbytes = True
+
+    # Check if we have the correct version (that exposes the `device` parameter).
+    try:
+        _ = bitsandbytes.nn.Linear8bitLt(1, 1, device=None)
+        _ = bitsandbytes.nn.Linear4bit(1, 1, device=None)
+        has_bitsandbytes_linear_device = True
+    except TypeError:
+        has_bitsandbytes_linear_device = False
 except ImportError:
     bitsandbytes = None  # type: ignore
     has_bitsandbytes = False
+    has_bitsandbytes_linear_device = False

--- a/curated_transformers/generation/dolly_v2.py
+++ b/curated_transformers/generation/dolly_v2.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Type, TypeVar
 import torch
 
 from ..models.gpt_neox.causal_lm import GPTNeoXCausalLM
+from ..quantization import BitsAndBytesConfig
 from ..tokenization.chunks import InputChunks, SpecialPieceChunk, TextChunk
 from ..tokenization.gpt_neox_tokenizer import GPTNeoXTokenizer
 from .config import GeneratorConfig
@@ -44,11 +45,15 @@ class DollyV2Generator(GeneratorWrapper, FromHFHub):
         *,
         name: str,
         revision: str = "main",
-        device: Optional[torch.device] = None
+        device: Optional[torch.device] = None,
+        quantization_config: Optional[BitsAndBytesConfig] = None,
     ) -> Self:
         tokenizer = GPTNeoXTokenizer.from_hf_hub(name=name, revision=revision)
         causal_lm = GPTNeoXCausalLM.from_hf_hub(
-            name=name, revision=revision, device=device
+            name=name,
+            revision=revision,
+            device=device,
+            quantization_config=quantization_config,
         )
         return cls(tokenizer, causal_lm)
 

--- a/curated_transformers/generation/falcon.py
+++ b/curated_transformers/generation/falcon.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Type, TypeVar
 import torch
 
 from ..models.refined_web_model.causal_lm import RefinedWebModelCausalLM
+from ..quantization.bnb.config import BitsAndBytesConfig
 from ..tokenization.chunks import InputChunks, TextChunk
 from ..tokenization.gpt_neox_tokenizer import GPTNeoXTokenizer
 from .config import GeneratorConfig
@@ -41,11 +42,15 @@ class FalconGenerator(GeneratorWrapper, FromHFHub):
         *,
         name: str,
         revision: str = "main",
-        device: Optional[torch.device] = None
+        device: Optional[torch.device] = None,
+        quantization_config: Optional[BitsAndBytesConfig] = None,
     ) -> Self:
         tokenizer = GPTNeoXTokenizer.from_hf_hub(name=name, revision=revision)
         causal_lm = RefinedWebModelCausalLM.from_hf_hub(
-            name=name, revision=revision, device=device
+            name=name,
+            revision=revision,
+            device=device,
+            quantization_config=quantization_config,
         )
         return cls(tokenizer, causal_lm)
 

--- a/curated_transformers/generation/hf_hub.py
+++ b/curated_transformers/generation/hf_hub.py
@@ -3,6 +3,8 @@ from typing import Optional, Type, TypeVar
 
 import torch
 
+from ..quantization import BitsAndBytesConfig
+
 # Only provided as typing.Self in Python 3.11+.
 Self = TypeVar("Self", bound="FromHFHub")
 
@@ -15,7 +17,8 @@ class FromHFHub(ABC):
         *,
         name: str,
         revision: str = "main",
-        device: Optional[torch.device] = None
+        device: Optional[torch.device] = None,
+        quantization_config: Optional[BitsAndBytesConfig] = None,
     ) -> Self:
         """Load a generator from Huggingface Hub."""
         ...

--- a/curated_transformers/models/gpt_neox/causal_lm.py
+++ b/curated_transformers/models/gpt_neox/causal_lm.py
@@ -1,9 +1,10 @@
-from typing import Any, List, Mapping, Optional, Type, TypeVar
+from typing import Any, List, Mapping, Optional, Set, Type, TypeVar
 
 import torch
 from torch import Tensor
 from torch.nn import Linear
 
+from ...quantization import Quantizable
 from ..attention import AttentionMask, KeyValueCache
 from ..hf_hub import FromPretrainedHFModel
 from ..module import CausalLMModule
@@ -16,7 +17,9 @@ from .decoder import GPTNeoXDecoder
 Self = TypeVar("Self", bound="GPTNeoXCausalLM")
 
 
-class GPTNeoXCausalLM(CausalLMModule[KeyValueCache], FromPretrainedHFModel):
+class GPTNeoXCausalLM(
+    CausalLMModule[KeyValueCache], FromPretrainedHFModel, Quantizable
+):
     """GPT-NeoX (Black et al, 2022) causal language model."""
 
     def __init__(
@@ -73,3 +76,8 @@ class GPTNeoXCausalLM(CausalLMModule[KeyValueCache], FromPretrainedHFModel):
     ) -> Self:
         config = convert_hf_config(hf_config)
         return cls(config, device=device)
+
+    @classmethod
+    def modules_to_not_quantize(cls) -> Set[str]:
+        # Ignore the LM head.
+        return {"output_embeddings"}

--- a/curated_transformers/quantization/__init__.py
+++ b/curated_transformers/quantization/__init__.py
@@ -1,0 +1,3 @@
+from .bnb import BitsAndBytesConfig
+from .helpers import prepare_module_for_quantization
+from .quantizable import Quantizable

--- a/curated_transformers/quantization/bnb/__init__.py
+++ b/curated_transformers/quantization/bnb/__init__.py
@@ -1,0 +1,2 @@
+from .config import BitsAndBytesConfig
+from .impl import prepare_for_quantization

--- a/curated_transformers/quantization/bnb/config.py
+++ b/curated_transformers/quantization/bnb/config.py
@@ -1,0 +1,79 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Union
+
+import torch
+
+
+class Dtype4Bit(str, Enum):
+    FP4 = "fp4"
+    NF4 = "nf4"
+
+
+@dataclass
+class _4BitConfig:
+    """Config for `fp4`/`nf4` quantization."""
+
+    quantization_dtype: Dtype4Bit
+    compute_dtype: torch.dtype
+    double_quantization: bool
+
+
+@dataclass
+class _8BitConfig:
+    """Config for `int8` quantization."""
+
+    fine_tunable: bool
+    outlier_threshold: float
+
+
+@dataclass
+class BitsAndBytesConfig:
+    """Config for quantization using `bitsandbytes`."""
+
+    inner: Union[_4BitConfig, _8BitConfig]
+
+    @staticmethod
+    def for_8bit(outlier_threshold: float = 6.0, fine_tunable: bool = False):
+        """Construct a config for `int8` quantization.
+
+        :param outlier_threshold:
+            Threshold for outlier detection during weight
+            decomposition.
+        :param fine_tunable:
+            If the quantized model should support fine-tuning after
+            quantization.
+        """
+        return BitsAndBytesConfig(
+            _8BitConfig(fine_tunable=fine_tunable, outlier_threshold=outlier_threshold)
+        )
+
+    @staticmethod
+    def for_4bit(
+        quantization_dtype: Dtype4Bit = Dtype4Bit.FP4,
+        compute_dtype: torch.dtype = torch.bfloat16,
+        double_quantization: bool = True,
+    ):
+        """Construct a config for `fp4`/`nf4` quantization.
+
+        :param quantization_dtype:
+            Data type used for storing quantized weights.
+        :param compute_dtype:
+            Data type used for performing computations. Supported types: `float16`, `bfloat16`, `float32`
+        :param double_quantization:
+            If the quantization constants should themselves be
+            quantized.
+        """
+        supported_compute_dtypes = (torch.float32, torch.float16, torch.bfloat16)
+        if compute_dtype not in supported_compute_dtypes:
+            raise ValueError(
+                f"Unsupported compute dtype `{compute_dtype}` for quantization, must be one of: {supported_compute_dtypes}"
+            )
+
+        return BitsAndBytesConfig(
+            _4BitConfig(
+                quantization_dtype=quantization_dtype,
+                compute_dtype=compute_dtype,
+                double_quantization=double_quantization,
+            )
+        )

--- a/curated_transformers/quantization/bnb/impl.py
+++ b/curated_transformers/quantization/bnb/impl.py
@@ -116,7 +116,7 @@ def _convert_tensor_to_quantized_parameter(
 
 def _init_8bit_linear(
     source: Module, config: Union[_8BitConfig, _4BitConfig], device: torch.device
-) -> bnb.nn.Linear8bitLt:
+) -> "bnb.nn.Linear8bitLt":
     assert isinstance(config, _8BitConfig)
     quantized_module = bnb.nn.Linear8bitLt(
         input_features=source.in_features,
@@ -131,7 +131,7 @@ def _init_8bit_linear(
 
 def _init_4bit_linear(
     source: Module, config: Union[_8BitConfig, _4BitConfig], device: torch.device
-) -> bnb.nn.Linear4bit:
+) -> "bnb.nn.Linear4bit":
     assert isinstance(config, _4BitConfig)
     quantized_module = bnb.nn.Linear4bit(
         input_features=source.in_features,

--- a/curated_transformers/quantization/bnb/impl.py
+++ b/curated_transformers/quantization/bnb/impl.py
@@ -16,6 +16,20 @@ def prepare_for_quantization(
     config: BitsAndBytesConfig,
     non_quantizable_module_prefixes: Set[str],
 ) -> Optional[TensorToParameterConverterT]:
+    """Prepares a PyTorch module for quantization using the ``bitsandbytes``
+    library.
+
+    :param module:
+        Module to prepare for quantization.
+    :param config:
+        ``bitsandbytes`` quantization configuration.
+    :param non_quantizable_module_prefixes:
+        Set of module prefixes that should not be quantized.
+    :returns:
+        An optional callback for converting non-quantized tensors
+        to parameters that are compatible with the ``bitsandbytes``
+        quantization backend.
+    """
     _assert_bitsandbytes_installed()
 
     # All inputs to quantized layers need to be of type `float16`.

--- a/curated_transformers/quantization/bnb/impl.py
+++ b/curated_transformers/quantization/bnb/impl.py
@@ -1,0 +1,152 @@
+from typing import Callable, Optional, Set, Union
+
+import torch
+from torch import Tensor
+from torch.nn import Module, Parameter
+
+from ..._compat import bitsandbytes as bnb
+from ..._compat import has_bitsandbytes
+from ...util.pytorch import ModuleIterator, apply_to_module
+from ...util.serde import TensorToParameterConverterT
+from .config import BitsAndBytesConfig, _4BitConfig, _8BitConfig
+
+
+def prepare_for_quantization(
+    module: Module,
+    config: BitsAndBytesConfig,
+    non_quantizable_module_prefixes: Set[str],
+) -> Optional[TensorToParameterConverterT]:
+    _assert_bitsandbytes_installed()
+
+    # All inputs to quantized layers need to be of type `float16`.
+    # TODO How do we exclude non-quantizable modules from this?
+    module.to(torch.float16)
+
+    if isinstance(config.inner, _8BitConfig):
+        _replace_quantizable_modules(
+            module, config.inner, non_quantizable_module_prefixes, _init_8bit_linear
+        )
+    elif isinstance(config.inner, _4BitConfig):
+        _replace_quantizable_modules(
+            module, config.inner, non_quantizable_module_prefixes, _init_4bit_linear
+        )
+    else:
+        raise ValueError(f"Unknown bitsandbytes config `{type(config)}`")
+
+    return _convert_tensor_to_quantized_parameter
+
+
+def _replace_quantizable_modules(
+    module: Module,
+    config: Union[_8BitConfig, _4BitConfig],
+    non_quantizable_module_prefixes: Set[str],
+    init_quantized_module: Callable[
+        [Module, Union[_8BitConfig, _4BitConfig], torch.device], Module
+    ],
+):
+    def apply(itr: ModuleIterator):
+        quantize_everything = len(non_quantizable_module_prefixes) == 0
+        if not quantize_everything and itr.prefix in non_quantizable_module_prefixes:
+            # Not a quantizable module.
+            return
+        elif itr.parent is None:
+            # Root module
+            return
+        elif not isinstance(itr.module, torch.nn.Linear):
+            # Only Linear modules can be quantized.
+            return
+
+        # Initialize on the original device, which should be the
+        # `meta` device at this stage.
+        device = next(itr.module.parameters()).device
+        quantized_module = init_quantized_module(itr.module, config, device)
+        itr.parent._modules[itr.name] = quantized_module
+
+    apply_to_module(module, apply)
+
+
+def _convert_tensor_to_quantized_parameter(
+    module: Module,
+    module_prefix: str,
+    parameter_name: str,
+    tensor: Tensor,
+    device: Optional[torch.device] = None,
+) -> Parameter:
+    if device is None or "cuda" not in device.type:
+        raise ValueError(
+            f"bitsandbytes quantization can only be performed on CUDA GPU devices"
+        )
+
+    old_param = module._parameters[parameter_name]
+    assert old_param is not None
+    if old_param.shape != tensor.shape:
+        raise ValueError(
+            f"Expected size of replacement for `{module_prefix}` to be {old_param.shape}, but got {tensor.shape}"
+        )
+
+    # Bias is stored as a regular, non-quantized parameter.
+    is_bias_param = parameter_name == "bias"
+    # All parameters need to be of dtype `float16` for quantization.
+    tensor = tensor.to(torch.float16)
+
+    is_8bit = isinstance(module, bnb.nn.Linear8bitLt)
+    is_4bit = isinstance(module, bnb.nn.Linear4bit)
+    is_non_quantized = not is_8bit and not is_4bit
+
+    if is_bias_param or is_non_quantized:
+        new_param = Parameter(tensor, requires_grad=old_param.requires_grad)
+    elif is_8bit:
+        assert isinstance(old_param, bnb.nn.Int8Params)
+        new_param = bnb.nn.Int8Params(
+            tensor, requires_grad=False, has_fp16_weights=old_param.has_fp16_weights
+        )
+    elif is_4bit:
+        assert isinstance(old_param, bnb.nn.Params4bit)
+        new_param = bnb.nn.Params4bit(
+            tensor,
+            requires_grad=False,
+            blocksize=old_param.blocksize,
+            compress_statistics=old_param.compress_statistics,
+            quant_type=old_param.quant_type,
+            quant_state=old_param.quant_state,
+        )
+
+    return new_param.to(device=device)  # type:ignore
+
+
+def _init_8bit_linear(
+    source: Module, config: Union[_8BitConfig, _4BitConfig], device: torch.device
+) -> bnb.nn.Linear8bitLt:
+    assert isinstance(config, _8BitConfig)
+    quantized_module = bnb.nn.Linear8bitLt(
+        input_features=source.in_features,
+        output_features=source.out_features,
+        bias=source.bias is not None,
+        has_fp16_weights=config.fine_tunable,
+        threshold=config.outlier_threshold,
+        device=device,
+    )
+    return quantized_module
+
+
+def _init_4bit_linear(
+    source: Module, config: Union[_8BitConfig, _4BitConfig], device: torch.device
+) -> bnb.nn.Linear4bit:
+    assert isinstance(config, _4BitConfig)
+    quantized_module = bnb.nn.Linear4bit(
+        input_features=source.in_features,
+        output_features=source.out_features,
+        bias=source.bias is not None,
+        compute_dtype=config.compute_dtype,
+        compress_statistics=config.double_quantization,
+        quant_type=config.quantization_dtype.value,
+        device=device,
+    )
+    return quantized_module
+
+
+def _assert_bitsandbytes_installed():
+    if not has_bitsandbytes:
+        raise ValueError(
+            "The `bitsandbytes` Python library is required for quantization support"
+        )

--- a/curated_transformers/quantization/bnb/impl.py
+++ b/curated_transformers/quantization/bnb/impl.py
@@ -164,3 +164,14 @@ def _assert_bitsandbytes_installed():
         raise ValueError(
             "The `bitsandbytes` Python library is required for quantization support"
         )
+
+    # Ensure that we have the correct version (that exposes the `device` parameter).
+    try:
+        _ = bnb.nn.Linear8bitLt(1, 1, device=torch.device("cpu"))
+        _ = bnb.nn.Linear4bit(1, 1, device=torch.device("cpu"))
+    except TypeError:
+        raise ValueError(
+            "The currently installed `bitsandbytes` library does not support "
+            "passing device parameters to its modules. Refer to the readme "
+            "for more information on the requirements"
+        )

--- a/curated_transformers/quantization/bnb/impl.py
+++ b/curated_transformers/quantization/bnb/impl.py
@@ -5,7 +5,7 @@ from torch import Tensor
 from torch.nn import Module, Parameter
 
 from ..._compat import bitsandbytes as bnb
-from ..._compat import has_bitsandbytes
+from ..._compat import has_bitsandbytes, has_bitsandbytes_linear_device
 from ...util.pytorch import ModuleIterator, apply_to_module
 from ...util.serde import TensorToParameterConverterT
 from .config import BitsAndBytesConfig, _4BitConfig, _8BitConfig
@@ -164,12 +164,7 @@ def _assert_bitsandbytes_installed():
         raise ValueError(
             "The `bitsandbytes` Python library is required for quantization support"
         )
-
-    # Ensure that we have the correct version (that exposes the `device` parameter).
-    try:
-        _ = bnb.nn.Linear8bitLt(1, 1, device=torch.device("cpu"))
-        _ = bnb.nn.Linear4bit(1, 1, device=torch.device("cpu"))
-    except TypeError:
+    elif not has_bitsandbytes_linear_device:
         raise ValueError(
             "The currently installed `bitsandbytes` library does not support "
             "passing device parameters to its modules. Refer to the readme "

--- a/curated_transformers/quantization/helpers.py
+++ b/curated_transformers/quantization/helpers.py
@@ -1,0 +1,30 @@
+from typing import Optional
+
+from torch.nn import Module
+
+from ..util.serde import TensorToParameterConverterT
+from .bnb import BitsAndBytesConfig
+from .bnb import prepare_for_quantization as bnb_prepare_for_quantization
+from .quantizable import Quantizable
+
+
+def prepare_module_for_quantization(
+    module: Module, config: BitsAndBytesConfig
+) -> Optional[TensorToParameterConverterT]:
+    """Prepares a module for quantiazation and returns an optional callback
+    to generate quantized parameter tensors.
+
+    :param module:
+        Top-level module to quantize. Should implement `Quantizable`.
+    :param config:
+        Configuration for the quantizer.
+    :returns:
+        A callable that converts a non-quantized tensor to a quantized
+        parameter.
+    """
+    if not isinstance(module, Quantizable):
+        raise ValueError(f"Module of type `{type(module)}` is not quantizable")
+    qmodel: Quantizable = module
+    non_quantizable_module_prefixes = qmodel.modules_to_not_quantize()
+
+    return bnb_prepare_for_quantization(module, config, non_quantizable_module_prefixes)

--- a/curated_transformers/quantization/quantizable.py
+++ b/curated_transformers/quantization/quantizable.py
@@ -1,0 +1,23 @@
+from abc import ABC, abstractmethod
+from typing import Set
+
+
+class Quantizable(ABC):
+    """Mixin class for models that are quantizable.
+
+    A module using this mixin provides the necessary configuration
+    and parameter information to quantize it on-the-fly during the
+    module loading phase.
+    """
+
+    @classmethod
+    @abstractmethod
+    def modules_to_not_quantize(cls) -> Set[str]:
+        """Returns a set of prefixes that specify which modules are to
+        be ignored during quantization.
+
+        :returns:
+            Set of module prefixes. If empty, all submodules will be
+            quantized.
+        """
+        raise NotImplementedError

--- a/curated_transformers/tests/generation/test_dolly_v2.py
+++ b/curated_transformers/tests/generation/test_dolly_v2.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-
 from curated_transformers.generation.config import (
     GreedyGeneratorConfig,
     SampleGeneratorConfig,

--- a/curated_transformers/tests/generation/test_dolly_v2.py
+++ b/curated_transformers/tests/generation/test_dolly_v2.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+
 from curated_transformers.generation.config import (
     GreedyGeneratorConfig,
     SampleGeneratorConfig,

--- a/curated_transformers/tests/quantization/test_generation.py
+++ b/curated_transformers/tests/quantization/test_generation.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+
 from curated_transformers._compat import has_bitsandbytes
 from curated_transformers.generation.config import GreedyGeneratorConfig
 from curated_transformers.generation.dolly_v2 import DollyV2Generator

--- a/curated_transformers/tests/quantization/test_generation.py
+++ b/curated_transformers/tests/quantization/test_generation.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 import pytest
 import torch
+
 from curated_transformers._compat import has_bitsandbytes
 from curated_transformers.generation.config import GreedyGeneratorConfig
 from curated_transformers.generation.dolly_v2 import DollyV2Generator

--- a/curated_transformers/tests/quantization/test_generation.py
+++ b/curated_transformers/tests/quantization/test_generation.py
@@ -1,0 +1,100 @@
+import pytest
+import torch
+from curated_transformers._compat import has_bitsandbytes
+from curated_transformers.generation.config import GreedyGeneratorConfig
+from curated_transformers.generation.dolly_v2 import DollyV2Generator
+from curated_transformers.quantization import BitsAndBytesConfig
+
+from ..conftest import GPU_TESTS_ENABLED
+
+
+@pytest.fixture(scope="module")
+def dolly_generator_8_bit():
+    return DollyV2Generator.from_hf_hub(
+        name="databricks/dolly-v2-3b",
+        device=torch.device("cuda", index=0),
+        quantization_config=BitsAndBytesConfig.for_8bit(),
+    )
+
+
+@pytest.fixture(scope="module")
+def dolly_generator_4_bit():
+    return DollyV2Generator.from_hf_hub(
+        name="databricks/dolly-v2-3b",
+        device=torch.device("cuda", index=0),
+        quantization_config=BitsAndBytesConfig.for_4bit(),
+    )
+
+
+@pytest.mark.veryslow
+@pytest.mark.skipif(not GPU_TESTS_ENABLED, reason="requires GPU")
+@pytest.mark.skipif(not has_bitsandbytes, reason="requires bitsandbytes")
+def test_8_bit_quantization(dolly_generator_8_bit):
+    prompts = [
+        "What is the Rust programming language?",
+        "What is spaCy?",
+    ]
+    expected = [
+        "Rust is a multi-paradigm, high-level, general-purpose programming language. Rust is designed to have a small, consistent, and predictable set of language features that together provide a high-level of productivity and reliability. Rust's",
+        "SpaCy is an open-source library for natural language processing (NLP) and language understanding (LU) on the web. It is designed to be fast, scalable, and easy to use.\n\n",
+    ]
+    generated = dolly_generator_8_bit(
+        prompts, config=GreedyGeneratorConfig(max_generated_pieces=50)
+    )
+    assert generated == expected
+
+    prompts = [
+        "What is spaCy?",
+        "What is the Rust programming language?",
+    ]
+    expected = expected[::-1]
+    generated = dolly_generator_8_bit(
+        prompts, config=GreedyGeneratorConfig(max_generated_pieces=50)
+    )
+    assert generated == expected
+
+
+@pytest.mark.veryslow
+@pytest.mark.skipif(not GPU_TESTS_ENABLED, reason="requires GPU")
+@pytest.mark.skipif(not has_bitsandbytes, reason="requires bitsandbytes")
+def test_4_bit_quantization(dolly_generator_4_bit):
+    prompts = [
+        "What is the Rust programming language?",
+        "What is spaCy?",
+    ]
+    expected = [
+        "Rust is a multi-paradigm, high-level, general-purpose programming language. Rust is a compiled language, but unlike other compiled languages, Rust guarantees memory safety, which means that all memory accesses are guaranteed to be valid.",
+        "SpaCy is an NLP library for the Python programming language. It is developed by the spacy team at IST Austria.\n\n",
+    ]
+    generated = dolly_generator_4_bit(
+        prompts, config=GreedyGeneratorConfig(max_generated_pieces=50)
+    )
+    assert generated == expected
+
+    prompts = [
+        "What is spaCy?",
+        "What is the Rust programming language?",
+    ]
+    expected = expected[::-1]
+    generated = dolly_generator_4_bit(
+        prompts, config=GreedyGeneratorConfig(max_generated_pieces=50)
+    )
+    assert generated == expected
+
+
+@pytest.mark.veryslow
+@pytest.mark.skipif(not has_bitsandbytes, reason="requires bitsandbytes")
+def test_on_non_gpu():
+    with pytest.raises(ValueError, match="only be performed on CUDA"):
+        model = DollyV2Generator.from_hf_hub(
+            name="databricks/dolly-v2-3b",
+            device=None,
+            quantization_config=BitsAndBytesConfig.for_8bit(),
+        )
+
+    with pytest.raises(ValueError, match="only be performed on CUDA"):
+        model = DollyV2Generator.from_hf_hub(
+            name="databricks/dolly-v2-3b",
+            device=torch.device("cpu"),
+            quantization_config=BitsAndBytesConfig.for_4bit(),
+        )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
This PR introduces [8-bit (mixed `int8` and `float16`)](https://arxiv.org/abs/2208.07339) and [4-bit (`FP4`/`NF4`](https://arxiv.org/abs/2305.14314)) direct quantization of weights using the [`bitsandbytes` library](https://github.com/TimDettmers/bitsandbytes). 

Currently, `models.FromPretrainedHFModel` and `generation.FromHFHub` accept an optional `BitsAndBytesConfig` dataclass with quantization parameters. When present, the weights are automatically quantized during deserialization. This is only available for models running on CUDA GPUs.

At the time of this PR, the current version of `bitsandbytes` (0.39.0) supports both 8-bit and 4-bit backends, but neither expose the `device` parameter in their `torch` modules. We have an [open PR](https://github.com/TimDettmers/bitsandbytes/pull/469) that adds this, but the ETA is currently unknown. In the meantime, we'll need to build the library from source using [this fork](https://github.com/shadeMe/bitsandbytes/tree/linear-layer-device) for testing purposes. 

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Enhancement

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
