### PR TITLE
Clean up the self-attention layer

### DIFF
--- a/curated_transformers/generation/generator.py
+++ b/curated_transformers/generation/generator.py
@@ -11,9 +11,9 @@ from curated_transformers.generation.config import (
 )
 from curated_transformers.generation.logits import LogitsTransform
 
-from ..models.attention import AttentionMask, CacheT
+from ..models.attention import AttentionMask
 from ..models.module import CausalLMModule
-from ..models.output import CausalLMOutputWithCache
+from ..models.output import CacheT, CausalLMOutputWithCache
 from .state import GeneratorState
 
 

--- a/curated_transformers/generation/state.py
+++ b/curated_transformers/generation/state.py
@@ -3,7 +3,7 @@ from typing import Generic, List, Optional, Tuple
 import torch
 from torch import Tensor
 
-from ..models.attention import CacheT
+from ..models.output import CacheT
 from .stop_conditions import StopCondition
 
 

--- a/curated_transformers/generation/string_generator.py
+++ b/curated_transformers/generation/string_generator.py
@@ -2,7 +2,7 @@ from typing import Generic, Iterable, List
 
 from curated_transformers.generation.config import GeneratorConfig
 
-from ..models.attention import CacheT
+from ..models.output import CacheT
 from ..tokenization.chunks import InputChunks
 from ..tokenization.tokenizer import Tokenizer
 from .generator import Generator

--- a/curated_transformers/models/attention.py
+++ b/curated_transformers/models/attention.py
@@ -174,6 +174,8 @@ class SelfAttention(Module):
     Transformer self-attention layer (Vaswani et al., 2017).
     """
 
+    rotary_embeds: Optional[QueryKeyRotaryEmbeddings]
+
     def __init__(
         self,
         *,
@@ -215,6 +217,8 @@ class SelfAttention(Module):
                 fraction=rotary_embeds.fraction,
                 dims_per_head=self.dims_per_head,
             )
+        else:
+            self.rotary_embeds = None
 
         self.attention = ScaledDotProductAttention(
             dropout_prob=dropout_prob,
@@ -271,7 +275,7 @@ class SelfAttention(Module):
 
         query, key, value = self._query_key_value(x)
 
-        if hasattr(self, "rotary_embeds"):
+        if self.rotary_embeds is not None:
             query, key = self.rotary_embeds(
                 query=query, key=key, cache=cache, positions=positions
             )

--- a/curated_transformers/models/attention.py
+++ b/curated_transformers/models/attention.py
@@ -181,7 +181,7 @@ class SelfAttention(Module):
         hidden_width: int,
         num_attention_heads: int,
         qkv_mode: QkvMode,
-        rotary_embeds: Optional[RotaryEmbeddingConfig],
+        rotary_embeds: Optional[RotaryEmbeddingConfig] = None,
         device: Optional[torch.device] = None,
     ):
         """Construct a self-attention layer with rotary position embeddings.
@@ -192,7 +192,7 @@ class SelfAttention(Module):
         :param num_attention_heads: Number of attention heads.
         :param qkv_mode: Handling mode for query, key and value.
         :param rotary_embeds: Configuration for rotary embeddings, rotary
-            embeddings wil not be used when set to ``None``.
+            embeddings will not be used when set to ``None``.
         :param device: Device on which the module is to be initialized.
         """
 

--- a/curated_transformers/models/bert/layer.py
+++ b/curated_transformers/models/bert/layer.py
@@ -24,6 +24,7 @@ class BertEncoderLayer(Module):
             hidden_width=attention_config.hidden_width,
             num_attention_heads=attention_config.num_attention_heads,
             qkv_mode=QkvMode.SEPARATE,
+            rotary_embeds=None,
             device=device,
         )
         self.attn_output_layernorm = torch.nn.LayerNorm(
@@ -47,7 +48,7 @@ class BertEncoderLayer(Module):
             x - (batch, seq_len, width)
             attention_mask - (batch, seq_len)
         """
-        attn_out = self.mha(x, attention_mask)
+        attn_out, _ = self.mha(x, attention_mask)
         attn_out = self.attn_output_dropout(attn_out)
         attn_out = self.attn_output_layernorm(x + attn_out)
 

--- a/curated_transformers/models/embeddings.py
+++ b/curated_transformers/models/embeddings.py
@@ -175,7 +175,7 @@ class QueryKeyRotaryEmbeddings(Module):
         representations.
 
         :param base: Base in signifying the rotary embedding period.
-        :param fraction: fraction of hidden width to apply rotary
+        :param fraction: Fraction of hidden width to apply rotary
             embeddings to. Must be in [0,1].
         :param dims_per_head: Width of key and value heads.
         :param device: Device on which the module is to be initialized.

--- a/curated_transformers/models/embeddings.py
+++ b/curated_transformers/models/embeddings.py
@@ -1,9 +1,11 @@
 import math
-from typing import Optional
+from typing import Optional, Tuple
 
 import torch
 from torch import Tensor
 from torch.nn import Module
+
+from .output import KeyValueCache
 
 
 # https://pytorch.org/tutorials/beginner/transformer_tutorial.html
@@ -155,3 +157,99 @@ class RotaryEmbeddings(Module):
 
         # Eq 34 with ordering changed for compatibility.
         return rot_cos * input + rot_sin * self._rotate(input)
+
+
+class QueryKeyRotaryEmbeddings(Module):
+    """Rotary embeddings applied to key and value representations"""
+
+    def __init__(
+        self,
+        *,
+        base: int = 10000,
+        fraction: float,
+        dims_per_head: int,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        """
+        Construct rotary embeddings for transforming key and value
+        representations.
+
+        :param base: Base in signifying the rotary embedding period.
+        :param fraction: fraction of hidden width to apply rotary
+            embeddings to. Must be in [0,1].
+        :param dims_per_head: Width of key and value heads.
+        :param device: Device on which the module is to be initialized.
+        """
+        super().__init__()
+        if not 0.0 <= fraction <= 1.0:
+            raise ValueError(
+                f"Rotary embedding fraction should be between 0.0 and 1.0 inclusive, was: {fraction}"
+            )
+        self.rotary_dims = int(fraction * dims_per_head)
+        self.dims_per_head = dims_per_head
+        self.rotary_embeds = RotaryEmbeddings(
+            width=self.rotary_dims, base=base, device=device
+        )
+
+    def forward(
+        self,
+        *,
+        query: Tensor,
+        key: Tensor,
+        cache: Optional[KeyValueCache] = None,
+        positions: Optional[Tensor] = None,
+    ) -> Tuple[Tensor, Tensor]:
+        """
+        Apply rotary embeddings to the query and key.
+
+        :param query:
+            Query representations.
+            **Shape:** (batch, head, seq_len, width_per_head)
+        :param key:
+            Key representations.
+            **Shape:** (batch, head, seq_len, width_per_head)
+        :param cache: Key/value cache to avoid recomputing
+            key/value representations for tokens that were previously seen.
+        :param positions: Input positions. Positions are needed to
+            look up rotary embeddings. Normally, these positions are calculated
+            automatically. But if the positions deviate for some reason, they
+            can be provided through this argument.
+        :returns:
+            Query and key with the rotary embeddings applied.
+            **Shape:** (batch, head, seq_len, width_per_head)
+        """
+        dims_per_head = self.dims_per_head
+        rotary_dims = self.rotary_dims
+
+        # If a cache was provided, but no positions, assume that the
+        # positions of the current batch continue from the cache.
+        if cache is not None and positions is None:
+            cache_len = cache.key.size(-2)
+            seq_len = key.size(-2)
+            positions = torch.arange(
+                cache_len,
+                cache_len + seq_len,
+                dtype=torch.long,  # `torch.int32` isn't supported in indexing operations prior in torch<2.0.0.
+                device=key.device,
+            ).repeat(key.size(0), 1)
+
+        if rotary_dims == dims_per_head:
+            # Fast path: we apply rotary embeddings the full key/query vectors.
+            key = self.rotary_embeds(key, positions=positions)
+            query = self.rotary_embeds(query, positions=positions)
+        else:
+            # Otherwise, split up key/query vectors, apply rotary embeddings
+            # and concatenate again.
+            k_rotary, k_rest = key.split([rotary_dims, dims_per_head - rotary_dims], -1)
+            q_rotary, q_rest = query.split(
+                [rotary_dims, dims_per_head - rotary_dims], -1
+            )
+
+            # Apply rotary embeddings.
+            k_rotary = self.rotary_embeds(k_rotary, positions=positions)
+            q_rotary = self.rotary_embeds(q_rotary, positions=positions)
+
+            query = torch.cat([q_rotary, q_rest], dim=-1)
+            key = torch.cat([k_rotary, k_rest], dim=-1)
+
+        return query, key

--- a/curated_transformers/models/gpt_neox/_hf.py
+++ b/curated_transformers/models/gpt_neox/_hf.py
@@ -65,7 +65,7 @@ def convert_hf_state_dict(cls, params: Mapping[str, Tensor]) -> Mapping[str, Ten
         name = re.sub(r"\.dense_4h_to_h", r".output", name)
 
         # Layer norms
-        name = re.sub(r"\.input_layernorm", r".mha_layer_norm", name)
+        name = re.sub(r"\.input_layernorm", r".input_layer_norm", name)
         name = re.sub(r"\.post_attention_layernorm", r".ffn_layer_norm", name)
         name = re.sub(r"final_layer_norm\.", r"output_layer_norm.", name)
 

--- a/curated_transformers/models/gpt_neox/causal_lm.py
+++ b/curated_transformers/models/gpt_neox/causal_lm.py
@@ -4,10 +4,10 @@ import torch
 from torch import Tensor
 from torch.nn import Linear
 
-from ..attention import AttentionMask, KeyValueCache
+from ..attention import AttentionMask
 from ..hf_hub import FromPretrainedHFModel
 from ..module import CausalLMModule
-from ..output import CausalLMOutputWithCache
+from ..output import CausalLMOutputWithCache, KeyValueCache
 from ._hf import convert_hf_config, convert_hf_state_dict
 from .config import GPTNeoXConfig
 from .decoder import GPTNeoXDecoder

--- a/curated_transformers/models/gpt_neox/decoder.py
+++ b/curated_transformers/models/gpt_neox/decoder.py
@@ -4,10 +4,10 @@ import torch
 from torch import Tensor
 from torch.nn import Dropout, Embedding, LayerNorm, ModuleList
 
-from ..attention import AttentionMask, KeyValueCache
+from ..attention import AttentionMask
 from ..hf_hub import FromPretrainedHFModel
 from ..module import DecoderModule
-from ..output import ModelOutputWithCache
+from ..output import KeyValueCache, ModelOutputWithCache
 from ._hf import convert_hf_config, convert_hf_state_dict
 from .config import GPTNeoXConfig
 from .layer import GPTNeoXDecoderLayer

--- a/curated_transformers/models/module.py
+++ b/curated_transformers/models/module.py
@@ -4,8 +4,8 @@ from typing import Generic, List, Optional
 from torch import Tensor
 from torch.nn import Module
 
-from .attention import AttentionMask, CacheT
-from .output import CausalLMOutputWithCache
+from .attention import AttentionMask
+from .output import CacheT, CausalLMOutputWithCache
 
 
 class CausalLMModule(Generic[CacheT], Module):

--- a/curated_transformers/models/output.py
+++ b/curated_transformers/models/output.py
@@ -1,9 +1,51 @@
-from typing import Generic, List, Optional, TypeVar
+from dataclasses import dataclass
+from typing import Generic, List, Optional, Protocol, TypeVar
 
 import torch
 from torch import Tensor
 
-CacheT = TypeVar("CacheT")
+CacheProtocolSelf = TypeVar("CacheProtocolSelf", bound="CacheProtocol")
+
+
+class CacheProtocol(Protocol):
+    def filter_batch_items(self: CacheProtocolSelf, mask: Tensor) -> CacheProtocolSelf:
+        """
+        Filter batch sequences from the cache.
+
+        Sequences for which the mask is ``True`` are retained.
+
+        :param mask:
+            Mask of batch items to retain.
+            **Shape:** (batch,)
+        :returns:
+            Filtered items.
+        """
+        ...
+
+
+CacheT = TypeVar("CacheT", bound=CacheProtocol)
+
+
+@dataclass
+class KeyValueCache:
+    """Cache type for layers that cache keys and values."""
+
+    key: Tensor
+    value: Tensor
+
+    def filter_batch_items(self, mask: Tensor) -> "KeyValueCache":
+        if mask.ndim != 1:
+            raise ValueError(
+                f"Cache mask must be a 1D tensor, has {mask.ndim} dimensions."
+            )
+        if mask.size(0) != self.key.size(0):
+            raise ValueError(
+                f"Cache mask size ({mask.size(0)}) must match cache batch size ({self.key.size(0)})."
+            )
+        if mask.dtype != torch.bool:
+            raise ValueError(f"Cache mask dtype must be bool, was: {mask.dtype}.")
+
+        return KeyValueCache(key=self.key[mask], value=self.value[mask])
 
 
 @torch.jit.script

--- a/docs/source/building-blocks.rst
+++ b/docs/source/building-blocks.rst
@@ -10,7 +10,7 @@ Attention
 .. autoclass:: curated_transformers.models.attention.AttentionMask
    :members:
 
-.. autoclass:: curated_transformers.models.attention.KeyValueCache
+.. autoclass:: curated_transformers.models.output.KeyValueCache
    :members:
 
 .. autoclass:: curated_transformers.models.attention.ScaledDotProductAttention


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

- Remove SelfAttention, rename SelfAttentionWithRotaryEmbeddings to SelfAttention.
- Factor out application of rotary embeddings to query and key to a separate module, to clean up SelfAttention.
- Factor out query, key, value and head construction, splitting, and head splitting to a separate method.
- Move cache protocol out of the attention module to avoid cycles.
- Rename mha_layer_norm to input_layer_norm, since in models with parallel connections this is fed both to both the attention block and the ff layers.
- Swap key, query argument order of ScaledDotProductAttention to be more canonical. Also make kwarg-only to avoid passing tensors in the wrong order.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Maintenance

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
