### PR TITLE
Add cache lookup fallback for `hf_hub_download` if the HF Hub is unreachable

### DIFF
--- a/curated_transformers/tokenization/hf_hub.py
+++ b/curated_transformers/tokenization/hf_hub.py
@@ -3,9 +3,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, Type, TypeVar
 
-from huggingface_hub import hf_hub_download
-
 from .._compat import has_hf_transformers, transformers
+from ..util.hf import hf_hub_download
 
 HF_TOKENIZER_FILENAME = "tokenizer.json"
 

--- a/curated_transformers/util/hf.py
+++ b/curated_transformers/util/hf.py
@@ -1,10 +1,11 @@
 import json
 import re
+import warnings
 from typing import List, Mapping
 
+import huggingface_hub
 import torch
-from huggingface_hub import hf_hub_download
-from requests import HTTPError  # type: ignore
+from requests import HTTPError, ReadTimeout  # type: ignore
 
 HF_MODEL_CONFIG = "config.json"
 HF_MODEL_CHECKPOINT = "pytorch_model.bin"
@@ -92,6 +93,46 @@ def get_model_checkpoint_filepaths(name: str, revision: str) -> List[str]:
         filepaths.append(resolved_filename)
 
     return sorted(filepaths)
+
+
+def hf_hub_download(repo_id: str, filename: str, revision: str) -> str:
+    """
+    Resolve the provided filename and repository to a local file path. If the file
+    is not present in the cache, it will be downloaded from the Hugging Face Hub.
+
+    :param repo_id:
+        Identifier of the source repository on Hugging Face Hub.
+    :param filename:
+        Name of the file in the source repository to download.
+    :param revision:
+        Source repository revision. Can either be a branch name
+        or a SHA hash of a commit.
+    :returns:
+        Resolved absolute filepath.
+    """
+
+    # The HF Hub library's `hf_hub_download` function will always attempt to connect to the
+    # remote repo and fetch its metadata even if it's locally cached (in order to update the
+    # out-of-date artifacts in the cache). This can occasionally lead to `HTTPError/ReadTimeout`s if the
+    # remote host is unreachable. Instead of failing loudly, we'll add a fallback that checks
+    # the local cache for the artifacts and uses them if found.
+    try:
+        resolved = huggingface_hub.hf_hub_download(
+            repo_id=repo_id, filename=filename, revision=revision
+        )
+    except (HTTPError, ReadTimeout) as e:
+        # Attempt to check the cache.
+        resolved = huggingface_hub.try_to_load_from_cache(
+            repo_id=repo_id, filename=filename, revision=revision
+        )
+        if resolved is None or resolved is huggingface_hub._CACHED_NO_EXIST:
+            # Not found, rethrow.
+            raise e
+        else:
+            warnings.warn(
+                f"Couldn't reach Hugging Face Hub; using cached artifact for '{repo_id}@{revision}:{filename}'"
+            )
+    return resolved
 
 
 def _rename_old_hf_names(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
The HF Hub library's `hf_hub_download` function will always attempt to connect to the  remote repo and fetch its metadata even if it's locally cached (in order to update the out-of-date artifacts in the cache). This can occasionally lead to `HTTPError/ReadTimeout`s if the remote host is unreachable. Instead of failing loudly, we'll add a fallback that checks the local cache for the artifacts and uses them if found.

The original HF Hub code does appear to have a such a built-in fallback, but it doesn't consistently work under all circumstances.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Bug fix/enhancement

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
