### PR TITLE
Fallback to the default device during `bitsandbytes` layer init

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,6 @@ pip install curated-transformers
 to build the library from source by cloning the [following branch](https://github.com/shadeMe/bitsandbytes/tree/linear-layer-device) of our fork. Installation instructions
 can be found [here](https://github.com/shadeMe/bitsandbytes/blob/linear-layer-device/compile_from_source.md).
 
-Users can still use the quantization feature without building the `bitsandbytes` library from our fork. However, they may encounter increased memory usage during the model
-initialization phase. The extra memory will be freed once the model has been successfully quantized.
+Users can still use the quantization feature without building the `bitsandbytes` library from our fork. However, this will result in increased CPU memory usage during the model
+initialization phase. The extra overhead amounts to about 2x the memory required for each model parameter, but this value is not cumulative as parameters are deserialized one-by-one.
+GPU memory usage remains unaffected.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ pip install curated-transformers
 
 ### Installation
 
-Since `curated-transformers` requires functionality that isn't currently present in `bitsandbytes` (as of `v0.39.0`), one needs to install the library
-from source by cloning the [following branch](https://github.com/shadeMe/bitsandbytes/tree/linear-layer-device) of our fork. Installation instructions
+`curated-transformers` requires functionality that isn't currently present in `bitsandbytes` (as of `v0.39.1`). While the said functionality is optional, we recommend users
+to build the library from source by cloning the [following branch](https://github.com/shadeMe/bitsandbytes/tree/linear-layer-device) of our fork. Installation instructions
 can be found [here](https://github.com/shadeMe/bitsandbytes/blob/linear-layer-device/compile_from_source.md).
+
+Users can still use the quantization feature without building the `bitsandbytes` library from our fork. However, they may encounter increased memory usage during the model
+initialization phase. The extra memory will be freed once the model has been successfully quantized.

--- a/curated_transformers/quantization/bnb/impl.py
+++ b/curated_transformers/quantization/bnb/impl.py
@@ -1,4 +1,5 @@
-from typing import Callable, Optional, Set, Union
+import warnings
+from typing import Any, Callable, Dict, Optional, Set, Union
 
 import torch
 from torch import Tensor
@@ -133,14 +134,17 @@ def _init_8bit_linear(
     source: Module, config: Union[_8BitConfig, _4BitConfig], device: torch.device
 ) -> "bnb.nn.Linear8bitLt":
     assert isinstance(config, _8BitConfig)
-    quantized_module = bnb.nn.Linear8bitLt(
-        input_features=source.in_features,
-        output_features=source.out_features,
-        bias=source.bias is not None,
-        has_fp16_weights=config.fine_tunable,
-        threshold=config.outlier_threshold,
-        device=device,
-    )
+    kwargs: Dict[str, Any] = {
+        "input_features": source.in_features,
+        "output_features": source.out_features,
+        "bias": source.bias is not None,
+        "has_fp16_weights": config.fine_tunable,
+        "threshold": config.outlier_threshold,
+    }
+    if has_bitsandbytes_linear_device:
+        kwargs["device"] = device
+
+    quantized_module = bnb.nn.Linear8bitLt(**kwargs)
     return quantized_module
 
 
@@ -148,15 +152,18 @@ def _init_4bit_linear(
     source: Module, config: Union[_8BitConfig, _4BitConfig], device: torch.device
 ) -> "bnb.nn.Linear4bit":
     assert isinstance(config, _4BitConfig)
-    quantized_module = bnb.nn.Linear4bit(
-        input_features=source.in_features,
-        output_features=source.out_features,
-        bias=source.bias is not None,
-        compute_dtype=config.compute_dtype,
-        compress_statistics=config.double_quantization,
-        quant_type=config.quantization_dtype.value,
-        device=device,
-    )
+    kwargs: Dict[str, Any] = {
+        "input_features": source.in_features,
+        "output_features": source.out_features,
+        "bias": source.bias is not None,
+        "compute_dtype": config.compute_dtype,
+        "compress_statistics": config.double_quantization,
+        "quant_type": config.quantization_dtype.value,
+    }
+    if has_bitsandbytes_linear_device:
+        kwargs["device"] = device
+
+    quantized_module = bnb.nn.Linear4bit(**kwargs)
     return quantized_module
 
 
@@ -166,8 +173,10 @@ def _assert_bitsandbytes_installed():
             "The `bitsandbytes` Python library is required for quantization support"
         )
     elif not has_bitsandbytes_linear_device:
-        raise ValueError(
-            "The currently installed `bitsandbytes` library does not support "
-            "passing device parameters to its modules. Refer to the readme "
-            "for more information on the requirements"
+        msg = (
+            "The installed version of the `bitsandbytes` library does not support passing "
+            "device parameters to its modules. This can result in increased memory usage "
+            "during model initialization. Please refer to the readme for more information."
         )
+        warnings.filterwarnings("once", msg)
+        warnings.warn(msg)

--- a/curated_transformers/quantization/bnb/impl.py
+++ b/curated_transformers/quantization/bnb/impl.py
@@ -176,7 +176,7 @@ def _assert_bitsandbytes_installed():
         msg = (
             "The installed version of the `bitsandbytes` library does not support passing "
             "device parameters to its modules. This can result in increased memory usage "
-            "during model initialization. Please refer to the readme for more information."
+            "during model initialization. Please refer to the README for more information."
         )
         warnings.filterwarnings("once", msg)
         warnings.warn(msg)

--- a/curated_transformers/tests/quantization/test_generation.py
+++ b/curated_transformers/tests/quantization/test_generation.py
@@ -2,7 +2,6 @@ from copy import deepcopy
 
 import pytest
 import torch
-
 from curated_transformers._compat import has_bitsandbytes
 from curated_transformers.generation.config import GreedyGeneratorConfig
 from curated_transformers.generation.dolly_v2 import DollyV2Generator
@@ -52,7 +51,7 @@ def _check_quantized_generator_output(output, expected_keywords):
 @pytest.mark.slow
 @pytest.mark.skipif(not GPU_TESTS_ENABLED, reason="requires GPU")
 @pytest.mark.skipif(not has_bitsandbytes, reason="requires bitsandbytes")
-def test_8_bit_quantization(dolly_generator_8_bit):
+def test_quantization_8_bit(dolly_generator_8_bit):
     prompts = deepcopy(PROMPTS_AND_KEYWORDS[0])
     expected = deepcopy(PROMPTS_AND_KEYWORDS[1])
     generated = dolly_generator_8_bit(
@@ -71,7 +70,7 @@ def test_8_bit_quantization(dolly_generator_8_bit):
 @pytest.mark.slow
 @pytest.mark.skipif(not GPU_TESTS_ENABLED, reason="requires GPU")
 @pytest.mark.skipif(not has_bitsandbytes, reason="requires bitsandbytes")
-def test_4_bit_quantization(dolly_generator_4_bit):
+def test_quantization_4_bit(dolly_generator_4_bit):
     prompts = deepcopy(PROMPTS_AND_KEYWORDS[0])
     expected = deepcopy(PROMPTS_AND_KEYWORDS[1])
     generated = dolly_generator_4_bit(
@@ -89,7 +88,7 @@ def test_4_bit_quantization(dolly_generator_4_bit):
 
 @pytest.mark.slow
 @pytest.mark.skipif(not has_bitsandbytes, reason="requires bitsandbytes")
-def test_on_non_gpu():
+def test_quantization_on_non_gpu():
     with pytest.raises(ValueError, match="only be performed on CUDA"):
         model = DollyV2Generator.from_hf_hub(
             name="databricks/dolly-v2-3b",

--- a/curated_transformers/tests/quantization/test_generation.py
+++ b/curated_transformers/tests/quantization/test_generation.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 import pytest
 import torch
+
 from curated_transformers._compat import has_bitsandbytes
 from curated_transformers.generation.config import GreedyGeneratorConfig
 from curated_transformers.generation.dolly_v2 import DollyV2Generator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Currently, we error out if the user attempts to use `bitsandbytes` quantization without having [our fork](https://github.com/shadeMe/bitsandbytes/tree/linear-layer-device) of the library installed. This PR removes that restriction at the expense of some extra memory usage.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Enhancement

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
