### PR TITLE
Speed up library import

### DIFF
--- a/curated_transformers/_compat.py
+++ b/curated_transformers/_compat.py
@@ -1,50 +1,16 @@
 import warnings
+from importlib.util import find_spec
 
-try:
-    import transformers
-
-    has_hf_transformers = True
-except ImportError:
-    transformers = None  # type: ignore
-    has_hf_transformers = False
-
-
-def _check_scipy_presence() -> bool:
-    try:
-        from scipy.stats import norm
-
-        return True
-    except ImportError:
-        return False
-
-
-def _check_bnb_presence() -> bool:
-    try:
-        import bitsandbytes
-    except ModuleNotFoundError:
-        return False
-    except ImportError:
-        pass
-    return True
-
+_has_scipy = find_spec("scipy") is not None and find_spec("scipy.stats") is not None
+has_bitsandbytes = find_spec("bitsandbytes") is not None
 
 # As of v0.40.0, `bitsandbytes` doesn't correctly specify `scipy` as an installation
 # dependency. This can lead to situations where the former is installed but
 # the latter isn't and the ImportError gets masked. So, we additionally check
 # for the presence of `scipy`.
-if _check_scipy_presence():
-    try:
-        import bitsandbytes
-
-        has_bitsandbytes = True
-    except ImportError:
-        bitsandbytes = None  # type: ignore
-        has_bitsandbytes = False
-else:
-    if _check_bnb_presence():
-        warnings.warn(
-            "The `bitsandbytes` library is installed but its dependency "
-            "`scipy` isn't. Please install `scipy` to correctly load `bitsandbytes`."
-        )
-    bitsandbytes = None  # type: ignore
+if has_bitsandbytes and not _has_scipy:
+    warnings.warn(
+        "The `bitsandbytes` library is installed but its dependency "
+        "`scipy` isn't. Please install `scipy` to correctly load `bitsandbytes`."
+    )
     has_bitsandbytes = False

--- a/curated_transformers/quantization/bnb/impl.py
+++ b/curated_transformers/quantization/bnb/impl.py
@@ -1,15 +1,21 @@
-import warnings
-from typing import Any, Callable, Dict, Optional, Set, Union
+from typing import TYPE_CHECKING, Callable, Optional, Set, Union
 
 import torch
 from torch import Tensor
 from torch.nn import Module, Parameter
 
-from ..._compat import bitsandbytes as bnb
 from ..._compat import has_bitsandbytes
 from ...util.pytorch import ModuleIterator, apply_to_module
 from ...util.serde import TensorToParameterConverterT
 from .config import BitsAndBytesConfig, _4BitConfig, _8BitConfig
+
+if TYPE_CHECKING:
+    try:
+        import bitsandbytes as bnb
+    except ImportError:
+        bnb = None
+else:
+    bnb = None
 
 
 def prepare_for_quantization(
@@ -100,6 +106,8 @@ def _convert_tensor_to_quantized_parameter(
             f"Expected size of replacement for `{module_prefix}` to be {old_param.shape}, but got {tensor.shape}"
         )
 
+    import bitsandbytes as bnb
+
     # Bias is stored as a regular, non-quantized parameter.
     is_bias_param = parameter_name == "bias"
     # All parameters need to be of dtype `float16` for quantization.
@@ -134,6 +142,8 @@ def _init_8bit_linear(
     source: Module, config: Union[_8BitConfig, _4BitConfig], device: torch.device
 ) -> "bnb.nn.Linear8bitLt":
     assert isinstance(config, _8BitConfig)
+    import bitsandbytes as bnb
+
     quantized_module = bnb.nn.Linear8bitLt(
         input_features=source.in_features,
         output_features=source.out_features,
@@ -149,6 +159,8 @@ def _init_4bit_linear(
     source: Module, config: Union[_8BitConfig, _4BitConfig], device: torch.device
 ) -> "bnb.nn.Linear4bit":
     assert isinstance(config, _4BitConfig)
+    import bitsandbytes as bnb
+
     quantized_module = bnb.nn.Linear4bit(
         input_features=source.in_features,
         output_features=source.out_features,

--- a/curated_transformers/quantization/bnb/impl.py
+++ b/curated_transformers/quantization/bnb/impl.py
@@ -10,10 +10,7 @@ from ...util.serde import TensorToParameterConverterT
 from .config import BitsAndBytesConfig, _4BitConfig, _8BitConfig
 
 if TYPE_CHECKING:
-    try:
-        import bitsandbytes as bnb
-    except ImportError:
-        bnb = None
+    import bitsandbytes as bnb
 else:
     bnb = None
 

--- a/curated_transformers/tests/compat.py
+++ b/curated_transformers/tests/compat.py
@@ -1,0 +1,7 @@
+try:
+    import transformers
+
+    has_hf_transformers = True
+except ImportError:
+    transformers = None  # type: ignore
+    has_hf_transformers = False

--- a/curated_transformers/tests/models/albert/test_encoder.py
+++ b/curated_transformers/tests/models/albert/test_encoder.py
@@ -1,8 +1,8 @@
 import pytest
 
-from curated_transformers._compat import has_hf_transformers
 from curated_transformers.models.albert import ALBERTConfig, ALBERTEncoder
 
+from ...compat import has_hf_transformers
 from ...conftest import TORCH_DEVICES
 from ..util import assert_encoder_output_equals_hf
 

--- a/curated_transformers/tests/models/bert/test_encoder.py
+++ b/curated_transformers/tests/models/bert/test_encoder.py
@@ -1,8 +1,8 @@
 import pytest
 
-from curated_transformers._compat import has_hf_transformers
 from curated_transformers.models.bert.encoder import BERTEncoder
 
+from ...compat import has_hf_transformers
 from ...conftest import TORCH_DEVICES
 from ..util import assert_encoder_output_equals_hf
 

--- a/curated_transformers/tests/models/camembert/test_encoder.py
+++ b/curated_transformers/tests/models/camembert/test_encoder.py
@@ -1,8 +1,8 @@
 import pytest
 
-from curated_transformers._compat import has_hf_transformers
 from curated_transformers.models.camembert.encoder import CamemBERTEncoder
 
+from ...compat import has_hf_transformers
 from ...conftest import TORCH_DEVICES
 from ..util import assert_encoder_output_equals_hf
 

--- a/curated_transformers/tests/models/gpt_neox/test_causal_lm.py
+++ b/curated_transformers/tests/models/gpt_neox/test_causal_lm.py
@@ -1,11 +1,11 @@
 import pytest
 import torch
 
-from curated_transformers._compat import has_hf_transformers, transformers
 from curated_transformers.layers.attention import AttentionMask
 from curated_transformers.models.gpt_neox.causal_lm import GPTNeoXCausalLM
 from curated_transformers.tests.util import torch_assertclose
 
+from ...compat import has_hf_transformers, transformers
 from ...conftest import TORCH_DEVICES
 
 

--- a/curated_transformers/tests/models/gpt_neox/test_decoder.py
+++ b/curated_transformers/tests/models/gpt_neox/test_decoder.py
@@ -1,11 +1,11 @@
 import pytest
 import torch
 
-from curated_transformers._compat import has_hf_transformers, transformers
 from curated_transformers.layers.attention import AttentionMask
 from curated_transformers.models.gpt_neox.decoder import GPTNeoXDecoder
 from curated_transformers.tests.util import torch_assertclose
 
+from ...compat import has_hf_transformers, transformers
 from ...conftest import TORCH_DEVICES
 
 

--- a/curated_transformers/tests/models/llama/test_causal_lm.py
+++ b/curated_transformers/tests/models/llama/test_causal_lm.py
@@ -1,11 +1,11 @@
 import pytest
 import torch
 
-from curated_transformers._compat import has_hf_transformers, transformers
 from curated_transformers.layers.attention import AttentionMask
 from curated_transformers.models.llama.causal_lm import LLaMACausalLM
 from curated_transformers.tests.util import torch_assertclose
 
+from ...compat import has_hf_transformers, transformers
 from ...conftest import TORCH_DEVICES
 
 

--- a/curated_transformers/tests/models/llama/test_decoder.py
+++ b/curated_transformers/tests/models/llama/test_decoder.py
@@ -1,11 +1,11 @@
 import pytest
 import torch
 
-from curated_transformers._compat import has_hf_transformers, transformers
 from curated_transformers.layers.attention import AttentionMask
 from curated_transformers.models.llama.decoder import LLaMADecoder
 from curated_transformers.tests.util import torch_assertclose
 
+from ...compat import has_hf_transformers, transformers
 from ...conftest import TORCH_DEVICES
 
 

--- a/curated_transformers/tests/models/refined_web_model/test_decoder.py
+++ b/curated_transformers/tests/models/refined_web_model/test_decoder.py
@@ -1,11 +1,11 @@
 import pytest
 import torch
 
-from curated_transformers._compat import has_hf_transformers, transformers
 from curated_transformers.layers.attention import AttentionMask
 from curated_transformers.models.refined_web_model.decoder import RefinedWebModelDecoder
 from curated_transformers.tests.util import torch_assertclose
 
+from ...compat import has_hf_transformers, transformers
 from ...conftest import TORCH_DEVICES
 
 VOCAB_SIZE = 1024

--- a/curated_transformers/tests/models/roberta/test_encoder.py
+++ b/curated_transformers/tests/models/roberta/test_encoder.py
@@ -1,8 +1,8 @@
 import pytest
 
-from curated_transformers._compat import has_hf_transformers
 from curated_transformers.models.roberta.encoder import RoBERTaEncoder
 
+from ...compat import has_hf_transformers
 from ...conftest import TORCH_DEVICES
 from ..util import assert_encoder_output_equals_hf
 

--- a/curated_transformers/tests/models/test_attention.py
+++ b/curated_transformers/tests/models/test_attention.py
@@ -1,7 +1,6 @@
 import pytest
 import torch
 
-from curated_transformers._compat import has_hf_transformers
 from curated_transformers.layers.attention import (
     _TORCH_SDP,
     AttentionMask,
@@ -11,6 +10,7 @@ from curated_transformers.models.bert.encoder import BERTEncoder
 from curated_transformers.models.gpt_neox.decoder import GPTNeoXDecoder
 from curated_transformers.tests.util import torch_assertclose
 
+from ..compat import has_hf_transformers
 from ..conftest import TORCH_DEVICES
 
 VOCAB_SIZE = 1024

--- a/curated_transformers/tests/models/test_embeddings.py
+++ b/curated_transformers/tests/models/test_embeddings.py
@@ -1,9 +1,9 @@
 import pytest
 import torch
 
-from curated_transformers._compat import has_hf_transformers
 from curated_transformers.layers.embeddings import RotaryEmbeddings
 
+from ..compat import has_hf_transformers
 from ..conftest import TORCH_DEVICES
 from ..util import torch_assertclose
 

--- a/curated_transformers/tests/models/test_hf_hub.py
+++ b/curated_transformers/tests/models/test_hf_hub.py
@@ -1,8 +1,8 @@
 import pytest
 
-from curated_transformers._compat import has_hf_transformers
 from curated_transformers.models.bert.encoder import BERTEncoder
 
+from ..compat import has_hf_transformers
 from ..conftest import TORCH_DEVICES
 from .util import assert_encoder_output_equals_hf
 

--- a/curated_transformers/tests/models/util.py
+++ b/curated_transformers/tests/models/util.py
@@ -2,10 +2,10 @@ from typing import Type
 
 import torch
 
-from curated_transformers._compat import transformers
 from curated_transformers.layers.attention import AttentionMask
 from curated_transformers.models.hf_hub import FromHFHub
 
+from ..compat import transformers
 from ..util import torch_assertclose
 
 

--- a/curated_transformers/tests/models/xlm_roberta/test_encoder.py
+++ b/curated_transformers/tests/models/xlm_roberta/test_encoder.py
@@ -1,8 +1,8 @@
 import pytest
 
-from curated_transformers._compat import has_hf_transformers
 from curated_transformers.models.xlm_roberta.encoder import XLMREncoder
 
+from ...compat import has_hf_transformers
 from ...conftest import TORCH_DEVICES
 from ..util import assert_encoder_output_equals_hf
 

--- a/curated_transformers/tests/tokenizers/legacy/test_bert_tokenizer.py
+++ b/curated_transformers/tests/tokenizers/legacy/test_bert_tokenizer.py
@@ -1,7 +1,6 @@
 import pytest
 import torch
 
-from curated_transformers._compat import has_hf_transformers
 from curated_transformers.tokenizers import PiecesWithIds
 from curated_transformers.tokenizers.chunks import (
     InputChunks,
@@ -14,6 +13,7 @@ from curated_transformers.tokenizers.legacy.bert_tokenizer import (
 )
 from curated_transformers.tokenizers.legacy.legacy_tokenizer import DefaultNormalizer
 
+from ...compat import has_hf_transformers
 from ...util import torch_assertclose
 from ..util import compare_tokenizer_outputs_with_hf_tokenizer
 

--- a/curated_transformers/tests/tokenizers/legacy/test_camembert_tokenizer.py
+++ b/curated_transformers/tests/tokenizers/legacy/test_camembert_tokenizer.py
@@ -1,12 +1,12 @@
 import pytest
 import torch
 
-from curated_transformers._compat import has_hf_transformers
 from curated_transformers.tokenizers import PiecesWithIds
 from curated_transformers.tokenizers.legacy.camembert_tokenizer import (
     CamemBERTTokenizer,
 )
 
+from ...compat import has_hf_transformers
 from ...util import torch_assertclose
 from ..util import compare_tokenizer_outputs_with_hf_tokenizer
 

--- a/curated_transformers/tests/tokenizers/legacy/test_llama_tokenizer.py
+++ b/curated_transformers/tests/tokenizers/legacy/test_llama_tokenizer.py
@@ -1,8 +1,8 @@
 import pytest
 
-from curated_transformers._compat import has_hf_transformers
 from curated_transformers.tokenizers.legacy import LLaMATokenizer
 
+from ...compat import has_hf_transformers
 from ..util import compare_tokenizer_outputs_with_hf_tokenizer
 
 

--- a/curated_transformers/tests/tokenizers/legacy/test_roberta_tokenizer.py
+++ b/curated_transformers/tests/tokenizers/legacy/test_roberta_tokenizer.py
@@ -1,10 +1,10 @@
 import pytest
 import torch
 
-from curated_transformers._compat import has_hf_transformers
 from curated_transformers.tokenizers import PiecesWithIds
 from curated_transformers.tokenizers.legacy import RoBERTaTokenizer
 
+from ...compat import has_hf_transformers
 from ...util import torch_assertclose
 from ..util import compare_tokenizer_outputs_with_hf_tokenizer
 

--- a/curated_transformers/tests/tokenizers/legacy/test_xlmr_tokenizer.py
+++ b/curated_transformers/tests/tokenizers/legacy/test_xlmr_tokenizer.py
@@ -1,10 +1,10 @@
 import pytest
 import torch
 
-from curated_transformers._compat import has_hf_transformers
 from curated_transformers.tokenizers import PiecesWithIds
 from curated_transformers.tokenizers.legacy.xlmr_tokenizer import XLMRTokenizer
 
+from ...compat import has_hf_transformers
 from ...util import torch_assertclose
 from ..util import compare_tokenizer_outputs_with_hf_tokenizer
 

--- a/curated_transformers/tests/tokenizers/test_tokenizer.py
+++ b/curated_transformers/tests/tokenizers/test_tokenizer.py
@@ -4,11 +4,11 @@ from typing import Optional
 
 import pytest
 
-from curated_transformers._compat import has_hf_transformers, transformers
 from curated_transformers.tokenizers import Tokenizer
 from curated_transformers.tokenizers.chunks import InputChunks, TextChunk
 from curated_transformers.util.hf import TOKENIZER_JSON
 
+from ..compat import has_hf_transformers, transformers
 from ..util import torch_assertclose
 from .util import compare_tokenizer_outputs_with_hf_tokenizer
 

--- a/curated_transformers/tests/tokenizers/util.py
+++ b/curated_transformers/tests/tokenizers/util.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
-from curated_transformers._compat import transformers
-
+from ..compat import transformers
 from ..util import torch_assertclose
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Any module that would import `_compat` would also import `transformers`, `bitsandbytes`, and `scipy` (when installed). This lead to a noticable delay when importing curated transformers. Speed up imports by making the following changes:

- `transformers` is only used in tests, so only load it in tests by introducing a `compat` module for tests.
- For the remaining modules in `compat`, use `find_spec` to verify the precense of the module rather than using `import` as the precense check.
- Lazily import `bitsandbytes` in `quantization.bnb.impl`.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Performance

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
