### PR TITLE
Make some changes to support `torch.compile` and add tests

### DIFF
--- a/curated_transformers/layers/activations.py
+++ b/curated_transformers/layers/activations.py
@@ -51,11 +51,7 @@ class GeluFast(Module):
 
             *Shape:* ``(batch_size, seq_len, width)``
         """
-        return (
-            0.5
-            * input
-            * (
-                1.0
-                + torch.tanh(input * 0.7978845608 * (1.0 + 0.044715 * input * input))
-            )
-        )
+        alpha = math.sqrt(2.0 / math.pi)
+        beta = 0.044715
+
+        return 0.5 * input * (1.0 + torch.tanh(alpha * (input + beta * input.pow(3))))

--- a/curated_transformers/layers/attention.py
+++ b/curated_transformers/layers/attention.py
@@ -1,7 +1,7 @@
 import math
 from contextlib import contextmanager
 from contextvars import ContextVar
-from enum import IntEnum
+from enum import Enum
 from typing import Optional, Tuple
 
 import torch
@@ -129,11 +129,7 @@ def create_causal_mask(query: Tensor, key: Tensor) -> AttentionMask:
     key_len = key.size(2)
 
     causal_mask = torch.tril(
-        torch.full(
-            (key_len, key_len),
-            True,
-            device=query.device,
-        ),
+        torch.ones((key_len, key_len), device=query.device, dtype=torch.bool),
     ).view(1, 1, key_len, key_len)
     return AttentionMask(causal_mask[:, :, key_len - query_len : key_len, :key_len])
 
@@ -212,26 +208,26 @@ class AttentionHeads:
         )
 
 
-class QkvMode(IntEnum):
+class QkvMode(Enum):
     """
     How the query, key and value projections are handled in
     the self-attention layer.
     """
 
     #: ``SEPARATE`` - Use separate projections for query, key and value.
-    SEPARATE = (0,)
+    SEPARATE = 0
 
     #: ``MERGED_SPLIT_BEFORE`` - Use a merged projection for query,
     #: key and value, and split heads before splitting the query, key
     #: and value representations. This ordering is incompatible with
     #: head sharing in keys or values.
 
-    MERGED_SPLIT_BEFORE = (1,)
+    MERGED_SPLIT_BEFORE = 1
 
     #: ``MERGED_SPLIT_AFTER`` - Use a merged projection for query,
     #: key and value, and split heads after splitting the query, key
     #: and value representations.
-    MERGED_SPLIT_AFTER = (2,)
+    MERGED_SPLIT_AFTER = 2
 
 
 class AttentionLinearBiases(Module):

--- a/curated_transformers/tests/compat.py
+++ b/curated_transformers/tests/compat.py
@@ -1,3 +1,6 @@
+import torch
+from torch.nn import Identity
+
 try:
     import transformers
 
@@ -5,3 +8,11 @@ try:
 except ImportError:
     transformers = None  # type: ignore
     has_hf_transformers = False
+
+has_torch_compile = hasattr(torch, "compile")
+if has_torch_compile:
+    # torch.compile is not supported on all Python versions and platforms.
+    try:
+        torch.compile(Identity(), disable=True)
+    except:
+        has_torch_compile = False

--- a/curated_transformers/tests/generation/test_logits.py
+++ b/curated_transformers/tests/generation/test_logits.py
@@ -101,7 +101,6 @@ def test_top_p_transform():
     )
 
     transform = TopPTransform(0.9)
-    print(transform(logits))
     torch_assertclose(
         transform(logits),
         torch.tensor([[4.0, 4.0, -3.4028e38, -3.4028e38, 3.5, -3.4028e38, 5.0, 3.4]]),

--- a/curated_transformers/tests/models/albert/test_encoder.py
+++ b/curated_transformers/tests/models/albert/test_encoder.py
@@ -2,7 +2,7 @@ import pytest
 
 from curated_transformers.models.albert import ALBERTConfig, ALBERTEncoder
 
-from ...compat import has_hf_transformers
+from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
 from ..util import assert_encoder_output_equals_hf
 
@@ -18,4 +18,17 @@ def test_rejects_incorrect_number_of_groups():
 def test_encoder(torch_device):
     assert_encoder_output_equals_hf(
         ALBERTEncoder, "explosion-testing/albert-test", torch_device
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.skipif(not has_torch_compile, reason="requires torch.compile")
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_encoder_torch_compile(torch_device):
+    assert_encoder_output_equals_hf(
+        ALBERTEncoder,
+        "explosion-testing/albert-test",
+        torch_device,
+        with_torch_compile=True,
     )

--- a/curated_transformers/tests/models/bert/test_encoder.py
+++ b/curated_transformers/tests/models/bert/test_encoder.py
@@ -2,7 +2,7 @@ import pytest
 
 from curated_transformers.models.bert.encoder import BERTEncoder
 
-from ...compat import has_hf_transformers
+from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
 from ..util import assert_encoder_output_equals_hf
 
@@ -12,4 +12,17 @@ from ..util import assert_encoder_output_equals_hf
 def test_encoder(torch_device):
     assert_encoder_output_equals_hf(
         BERTEncoder, "explosion-testing/bert-test", torch_device
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.skipif(not has_torch_compile, reason="requires torch.compile")
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_encoder_torch_compile(torch_device):
+    assert_encoder_output_equals_hf(
+        BERTEncoder,
+        "explosion-testing/bert-test",
+        torch_device,
+        with_torch_compile=True,
     )

--- a/curated_transformers/tests/models/camembert/test_encoder.py
+++ b/curated_transformers/tests/models/camembert/test_encoder.py
@@ -2,7 +2,7 @@ import pytest
 
 from curated_transformers.models.camembert.encoder import CamemBERTEncoder
 
-from ...compat import has_hf_transformers
+from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
 from ..util import assert_encoder_output_equals_hf
 
@@ -12,4 +12,17 @@ from ..util import assert_encoder_output_equals_hf
 def test_encoder(torch_device):
     assert_encoder_output_equals_hf(
         CamemBERTEncoder, "explosion-testing/camembert-test", torch_device
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.skipif(not has_torch_compile, reason="requires torch.compile")
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_encoder_torch_compile(torch_device):
+    assert_encoder_output_equals_hf(
+        CamemBERTEncoder,
+        "explosion-testing/camembert-test",
+        torch_device,
+        with_torch_compile=True,
     )

--- a/curated_transformers/tests/models/gpt_neox/test_causal_lm.py
+++ b/curated_transformers/tests/models/gpt_neox/test_causal_lm.py
@@ -1,38 +1,30 @@
 import pytest
-import torch
 
-from curated_transformers.layers.attention import AttentionMask
 from curated_transformers.models.gpt_neox.causal_lm import GPTNeoXCausalLM
-from curated_transformers.tests.util import torch_assertclose
 
-from ...compat import has_hf_transformers, transformers
+from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
+from ..util import assert_causal_lm_output_equals_hf
 
 
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 @pytest.mark.parametrize("torch_device", TORCH_DEVICES)
-def test_causal_lm_against_hf(torch_device):
-    hf_model = transformers.AutoModelForCausalLM.from_pretrained(
-        "trl-internal-testing/tiny-random-GPTNeoXForCausalLM"
+def test_causal_lm(torch_device):
+    assert_causal_lm_output_equals_hf(
+        GPTNeoXCausalLM,
+        "trl-internal-testing/tiny-random-GPTNeoXForCausalLM",
+        torch_device,
     )
-    hf_model.eval()
-    hf_model.to(torch_device)
 
-    model = GPTNeoXCausalLM.from_hf_hub(
-        name="trl-internal-testing/tiny-random-GPTNeoXForCausalLM", device=torch_device
+
+@pytest.mark.slow
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.skipif(not has_torch_compile, reason="requires torch.compile")
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_causal_lm_torch_compile(torch_device):
+    assert_causal_lm_output_equals_hf(
+        GPTNeoXCausalLM,
+        "trl-internal-testing/tiny-random-GPTNeoXForCausalLM",
+        torch_device,
+        with_torch_compile=True,
     )
-    model.eval()
-
-    torch.manual_seed(0)
-    X = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)
-
-    with torch.no_grad():
-        Y = model(X).logits
-        Y_hf = hf_model(X).logits
-    torch_assertclose(Y, Y_hf)
-
-    mask = torch.rand((2, 10), dtype=torch.float, device=torch_device) < 0.5
-    with torch.no_grad():
-        Y = model(X, attention_mask=AttentionMask(mask)).logits * mask.unsqueeze(-1)
-        Y_hf = hf_model(X, attention_mask=mask).logits * mask.unsqueeze(-1)
-    torch_assertclose(Y, Y_hf)

--- a/curated_transformers/tests/models/llama/test_causal_lm.py
+++ b/curated_transformers/tests/models/llama/test_causal_lm.py
@@ -1,38 +1,30 @@
 import pytest
-import torch
 
-from curated_transformers.layers.attention import AttentionMask
 from curated_transformers.models.llama.causal_lm import LLaMACausalLM
-from curated_transformers.tests.util import torch_assertclose
 
-from ...compat import has_hf_transformers, transformers
+from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
+from ..util import assert_causal_lm_output_equals_hf
 
 
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 @pytest.mark.parametrize("torch_device", TORCH_DEVICES)
-def test_causal_lm_against_hf(torch_device):
-    hf_model = transformers.AutoModelForCausalLM.from_pretrained(
-        "trl-internal-testing/tiny-random-LlamaForCausalLM"
+def test_causal_lm(torch_device):
+    assert_causal_lm_output_equals_hf(
+        LLaMACausalLM,
+        "trl-internal-testing/tiny-random-LlamaForCausalLM",
+        torch_device,
     )
-    hf_model.eval()
-    hf_model.to(torch_device)
 
-    model = LLaMACausalLM.from_hf_hub(
-        name="trl-internal-testing/tiny-random-LlamaForCausalLM", device=torch_device
+
+@pytest.mark.slow
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.skipif(not has_torch_compile, reason="requires torch.compile")
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_causal_lm_torch_compile(torch_device):
+    assert_causal_lm_output_equals_hf(
+        LLaMACausalLM,
+        "trl-internal-testing/tiny-random-LlamaForCausalLM",
+        torch_device,
+        with_torch_compile=True,
     )
-    model.eval()
-
-    torch.manual_seed(0)
-    X = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)
-
-    with torch.no_grad():
-        Y = model(X).logits
-        Y_hf = hf_model(X).logits
-    torch_assertclose(Y, Y_hf)
-
-    mask = torch.rand((2, 10), dtype=torch.float, device=torch_device) < 0.5
-    with torch.no_grad():
-        Y = model(X, attention_mask=AttentionMask(mask)).logits * mask.unsqueeze(-1)
-        Y_hf = hf_model(X, attention_mask=mask).logits * mask.unsqueeze(-1)
-    torch_assertclose(Y, Y_hf)

--- a/curated_transformers/tests/models/llama/test_decoder.py
+++ b/curated_transformers/tests/models/llama/test_decoder.py
@@ -1,110 +1,28 @@
 import pytest
-import torch
 
-from curated_transformers.layers.attention import AttentionMask
 from curated_transformers.models.llama.decoder import LLaMADecoder
-from curated_transformers.tests.util import torch_assertclose
 
-from ...compat import has_hf_transformers, transformers
+from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
+from ..util import assert_decoder_output_equals_hf
 
 
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 @pytest.mark.parametrize("torch_device", TORCH_DEVICES)
 def test_decoder(torch_device):
-    hf_model = transformers.AutoModel.from_pretrained(
-        "trl-internal-testing/tiny-random-LlamaForCausalLM"
+    assert_decoder_output_equals_hf(
+        LLaMADecoder, "trl-internal-testing/tiny-random-LlamaForCausalLM", torch_device
     )
-    hf_model.to(torch_device)
-    hf_model.eval()
-
-    model = LLaMADecoder.from_hf_hub(
-        name="trl-internal-testing/tiny-random-LlamaForCausalLM", device=torch_device
-    )
-    model.eval()
-
-    torch.manual_seed(0)
-    X = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)
-
-    with torch.no_grad():
-        Y = model(X).last_hidden_layer_state
-        Y_hf = hf_model(X).last_hidden_state
-
-    torch_assertclose(Y, Y_hf)
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.skipif(not has_torch_compile, reason="requires torch.compile")
 @pytest.mark.parametrize("torch_device", TORCH_DEVICES)
-def test_decoder_with_cache(torch_device):
-    hf_model = transformers.AutoModel.from_pretrained(
-        "trl-internal-testing/tiny-random-LlamaForCausalLM"
+def test_decoder_with_torch_compile(torch_device):
+    assert_decoder_output_equals_hf(
+        LLaMADecoder,
+        "trl-internal-testing/tiny-random-LlamaForCausalLM",
+        torch_device,
+        with_torch_compile=True,
     )
-    hf_model.to(torch_device)
-    hf_model.eval()
-
-    model = LLaMADecoder.from_hf_hub(
-        name="trl-internal-testing/tiny-random-LlamaForCausalLM", device=torch_device
-    )
-    model.eval()
-
-    torch.manual_seed(0)
-    X = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)
-    X_rest = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)
-
-    with torch.no_grad():
-        Y = model(X, store_cache=True)
-        Y_hf = hf_model(X, use_cache=True)
-        Y = model(X_rest, cache=Y.cache).last_hidden_layer_state
-        Y_hf = hf_model(X_rest, past_key_values=Y_hf.past_key_values).last_hidden_state
-
-    torch_assertclose(Y, Y_hf)
-
-
-@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
-@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
-def test_decoder_with_positions(torch_device):
-    hf_model = transformers.AutoModel.from_pretrained(
-        "trl-internal-testing/tiny-random-LlamaForCausalLM"
-    )
-    hf_model.to(torch_device)
-    hf_model.eval()
-
-    model = LLaMADecoder.from_hf_hub(
-        name="trl-internal-testing/tiny-random-LlamaForCausalLM", device=torch_device
-    )
-    model.eval()
-
-    torch.manual_seed(0)
-    X = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)
-    positions = torch.randint(0, 10, (2, 10), device=torch_device)
-
-    with torch.no_grad():
-        Y = model(X, positions=positions).last_hidden_layer_state
-        Y_hf = hf_model(X, position_ids=positions).last_hidden_state
-    torch_assertclose(Y, Y_hf)
-
-
-@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
-@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
-def test_decoder_with_mask(torch_device):
-    hf_model = transformers.AutoModel.from_pretrained(
-        "trl-internal-testing/tiny-random-LlamaForCausalLM"
-    )
-    hf_model.to(torch_device)
-    hf_model.eval()
-
-    model = LLaMADecoder.from_hf_hub(
-        name="trl-internal-testing/tiny-random-LlamaForCausalLM", device=torch_device
-    )
-    model.eval()
-
-    torch.manual_seed(0)
-    X = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)
-
-    mask = torch.rand((2, 10), dtype=torch.float, device=torch_device) < 0.5
-    with torch.no_grad():
-        Y = model(
-            X, attention_mask=AttentionMask(mask)
-        ).last_hidden_layer_state * mask.unsqueeze(-1)
-        Y_hf = hf_model(X, attention_mask=mask).last_hidden_state * mask.unsqueeze(-1)
-    torch_assertclose(Y, Y_hf)

--- a/curated_transformers/tests/models/roberta/test_encoder.py
+++ b/curated_transformers/tests/models/roberta/test_encoder.py
@@ -2,7 +2,7 @@ import pytest
 
 from curated_transformers.models.roberta.encoder import RoBERTaEncoder
 
-from ...compat import has_hf_transformers
+from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
 from ..util import assert_encoder_output_equals_hf
 
@@ -12,4 +12,17 @@ from ..util import assert_encoder_output_equals_hf
 def test_encoder(torch_device):
     assert_encoder_output_equals_hf(
         RoBERTaEncoder, "explosion-testing/roberta-test", torch_device
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.skipif(not has_torch_compile, reason="requires torch.compile")
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_encoder_torch_compile(torch_device):
+    assert_encoder_output_equals_hf(
+        RoBERTaEncoder,
+        "explosion-testing/roberta-test",
+        torch_device,
+        with_torch_compile=True,
     )

--- a/curated_transformers/tests/models/util.py
+++ b/curated_transformers/tests/models/util.py
@@ -9,19 +9,151 @@ from ..compat import transformers
 from ..util import torch_assertclose
 
 
+def assert_causal_lm_output_equals_hf(
+    model_class: Type[FromHFHub],
+    model_name: str,
+    torch_device: torch.device,
+    *,
+    atol=1e-5,
+    rtol=1e-5,
+    model_revision: str = "main",
+    with_torch_compile: bool = False,
+):
+    model = model_class.from_hf_hub(
+        name=model_name, revision=model_revision, device=torch_device
+    )
+    model.eval()
+
+    for _, param in model.state_dict().items():
+        assert param.device == torch_device
+
+    if with_torch_compile:
+        model = torch.compile(model)
+
+    hf_model = transformers.AutoModelForCausalLM.from_pretrained(
+        model_name,
+        revision=model_revision,
+    )
+    hf_model.eval()
+    hf_model.to(torch_device)
+
+    torch.manual_seed(0)
+    X = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)
+
+    with torch.no_grad():
+        Y = model(X).logits
+        Y_hf = hf_model(X).logits
+    torch_assertclose(Y, Y_hf, atol=atol, rtol=rtol)
+
+    mask = torch.rand((2, 10), dtype=torch.float, device=torch_device) < 0.5
+    with torch.no_grad():
+        Y = model(X, attention_mask=AttentionMask(mask)).logits * mask.unsqueeze(-1)
+        Y_hf = hf_model(X, attention_mask=mask).logits * mask.unsqueeze(-1)
+    torch_assertclose(Y, Y_hf, atol=atol, rtol=rtol)
+
+
+def assert_decoder_output_equals_hf(
+    model_class: Type[FromHFHub],
+    model_name: str,
+    torch_device: torch.device,
+    *,
+    atol=1e-5,
+    rtol=1e-5,
+    model_revision: str = "main",
+    trust_remote_code: bool = False,
+    with_cache: bool = True,
+    with_positions: bool = True,
+    with_mask: bool = True,
+    with_torch_compile: bool = False,
+):
+    model = model_class.from_hf_hub(
+        name=model_name, revision=model_revision, device=torch_device
+    )
+    model.eval()
+
+    for _, param in model.state_dict().items():
+        assert param.device == torch_device
+
+    if with_torch_compile:
+        model = torch.compile(model)
+
+    hf_model = transformers.AutoModel.from_pretrained(
+        model_name, revision=model_revision, trust_remote_code=trust_remote_code
+    )
+    hf_model.to(torch_device)
+    hf_model.eval()
+
+    torch.manual_seed(0)
+    X = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)
+
+    with torch.no_grad():
+        Y = model(X).last_hidden_layer_state
+        Y_hf = hf_model(X).last_hidden_state
+
+    torch_assertclose(Y, Y_hf, atol=atol, rtol=rtol)
+
+    if with_cache:
+        X_rest = torch.randint(
+            0, hf_model.config.vocab_size, (2, 10), device=torch_device
+        )
+
+        with torch.no_grad():
+            Y = model(X, store_cache=True)
+            Y_hf = hf_model(X, use_cache=True)
+            Y = model(X_rest, cache=Y.cache).last_hidden_layer_state
+            Y_hf = hf_model(
+                X_rest, past_key_values=Y_hf.past_key_values
+            ).last_hidden_state
+
+        torch_assertclose(Y, Y_hf, atol=atol, rtol=rtol)
+
+    if with_positions:
+        # NOTE: this test may break in the future because we are relying on a
+        #       slicing bug, which results in more general support for positions
+        #       (like our implementation):
+        #
+        #       https://github.com/huggingface/transformers/blob/f924df3c7e5150317ef47754a31cebf2893570ce/src/transformers/models/gpt_neox/modeling_gpt_neox.py#L278
+        #
+        #       However, it is still nice to test this with arbitrary positions. If
+        #       this breaks, just replace max_position_embbeddings by the sequence
+        #       length.
+        positions = torch.randint(0, 10, (2, 10), device=torch_device)
+
+        with torch.no_grad():
+            Y = model(X, positions=positions).last_hidden_layer_state
+            Y_hf = hf_model(X, position_ids=positions).last_hidden_state
+
+        torch_assertclose(Y, Y_hf, atol=atol, rtol=rtol)
+
+    if with_mask:
+        mask = torch.rand((2, 10), dtype=torch.float, device=torch_device) < 0.5
+        with torch.no_grad():
+            Y = model(
+                X, attention_mask=AttentionMask(mask)
+            ).last_hidden_layer_state * mask.unsqueeze(-1)
+            Y_hf = hf_model(X, attention_mask=mask).last_hidden_state * mask.unsqueeze(
+                -1
+            )
+        torch_assertclose(Y, Y_hf, atol=atol, rtol=rtol)
+
+
 def assert_encoder_output_equals_hf(
     model_class: Type[FromHFHub],
     model_name: str,
     torch_device: torch.device,
     *,
     atol=1e-5,
-    rtol=1e-5
+    rtol=1e-5,
+    with_torch_compile: bool = False,
 ):
     model = model_class.from_hf_hub(name=model_name, device=torch_device)
     model.eval()
 
     for _, param in model.state_dict().items():
         assert param.device == torch_device
+
+    if with_torch_compile:
+        model = torch.compile(model)
 
     hf_model = transformers.AutoModel.from_pretrained(model_name)
     hf_model.to(torch_device)

--- a/curated_transformers/tests/models/xlm_roberta/test_encoder.py
+++ b/curated_transformers/tests/models/xlm_roberta/test_encoder.py
@@ -2,7 +2,7 @@ import pytest
 
 from curated_transformers.models.xlm_roberta.encoder import XLMREncoder
 
-from ...compat import has_hf_transformers
+from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
 from ..util import assert_encoder_output_equals_hf
 
@@ -12,4 +12,17 @@ from ..util import assert_encoder_output_equals_hf
 def test_encoder(torch_device):
     assert_encoder_output_equals_hf(
         XLMREncoder, "explosion-testing/xlm-roberta-test", torch_device
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.skipif(not has_torch_compile, reason="requires torch.compile")
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_encoder_torch_compile(torch_device):
+    assert_encoder_output_equals_hf(
+        XLMREncoder,
+        "explosion-testing/xlm-roberta-test",
+        torch_device,
+        with_torch_compile=True,
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Supporting `torch.compile` requires some small changes:

- We can't use `IntEnum`, replace single use by `Enum`.
- In the causal mask generation, the data type gets inferred incorrectly, explicitly give the `dtype`.

This change also adds tests for `torch.compile`. To avoid repetitiveness, factor out decoder tests similar to encoder tests.

In the `torch.compile` test for NeoX we disable testing with cache and positions. `torch.compile` is tripping over the rotary embeddings code where the rotary embeddings are only applied to part of the query/key representations.

While debugging, I also found that `GeluNew` can be implemented with fewer operations.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Feature/tests

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
