### PR TITLE
Make `DataclassAsTuple` types actual tuples

### DIFF
--- a/curated_transformers/layers/cache.py
+++ b/curated_transformers/layers/cache.py
@@ -78,7 +78,7 @@ class KeyValueCache(DataclassAsTuple):
             or not all(isinstance(item, Tensor) for item in key_value_cache)
         ):
             raise ValueError(
-                f"Key-value cache is not of the `KeyValueCache` type, nor Tuple[Tensor, Tensor]: {type(key_value_cache).__name__}"
+                f"Key-value cache is not of the `KeyValueCache` type, nor `Tuple[Tensor, Tensor]`: `{type(key_value_cache).__name__}`"
             )
 
         key_cache = key_value_cache[0]

--- a/curated_transformers/layers/cache.py
+++ b/curated_transformers/layers/cache.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Optional, Protocol, Type, TypeVar, Union
+from typing import Dict, Optional, Protocol, Tuple, Type, TypeVar, Union
 
 import torch
 from torch import Tensor
@@ -27,7 +27,7 @@ class CacheProtocol(Protocol):
 
 
 @dataclass
-class KeyValueCache(DataclassAsDict):
+class KeyValueCache(DataclassAsTuple):
     """
     Cache type for layers that cache keys and values.
 
@@ -57,7 +57,7 @@ class KeyValueCache(DataclassAsDict):
     @classmethod
     def jit_rewrap(
         cls: Type["KeyValueCache"],
-        key_value_cache: Optional[Union["KeyValueCache", Dict[str, Tensor]]],
+        key_value_cache: Optional[Union["KeyValueCache", Tuple[Tensor, Tensor]]],
     ) -> Optional["KeyValueCache"]:
         """
         Rewrap TorchScript dictionary conversion of a key-value cache.
@@ -72,16 +72,21 @@ class KeyValueCache(DataclassAsDict):
         if key_value_cache is None or isinstance(key_value_cache, KeyValueCache):
             return key_value_cache
 
-        key = key_value_cache.get("key")
-        if key is None:
+        if (
+            not isinstance(key_value_cache, tuple)
+            or len(key_value_cache) != 2
+            or not all(isinstance(item, Tensor) for item in key_value_cache)
+        ):
             raise ValueError(
-                "Key-value cache is not of the `KeyValueCache` type, nor a dict with 'key'."
+                f"Key-value cache is not of the `KeyValueCache` type, nor Tuple[Tensor, Tensor]: {type(key_value_cache).__name__}"
             )
 
-        value = key_value_cache.get("value")
-        if value is None:
+        key_cache = key_value_cache[0]
+        value_cache = key_value_cache[1]
+
+        if key_cache.shape != value_cache.shape:
             raise ValueError(
-                "Key-value cache is not of the `KeyValueCache`` type, nor a dict with 'value'."
+                f"Key cache ({key_cache.shape}) and value cache ({value_cache.shape}) must have same shapes."
             )
 
-        return cls(key=key, value=value)
+        return cls(key_cache, value_cache)

--- a/curated_transformers/models/albert/encoder.py
+++ b/curated_transformers/models/albert/encoder.py
@@ -81,12 +81,7 @@ class ALBERTEncoder(EncoderModule, FromHFHub):
                 layer_output, _ = group(layer_output, attention_mask=attention_mask)
                 layer_outputs.append(layer_output)
 
-        output = ModelOutput(all_outputs=[embeddings, *layer_outputs])
-
-        if torch.jit.is_tracing():
-            return output.astuple()  # type: ignore[return-value]
-        else:
-            return output
+        return ModelOutput(all_outputs=[embeddings, *layer_outputs])
 
     @classmethod
     def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):

--- a/curated_transformers/models/bert/encoder.py
+++ b/curated_transformers/models/bert/encoder.py
@@ -108,12 +108,7 @@ class BERTEncoder(EncoderModule, FromHFHub):
             layer_output, _ = layer(layer_output, attention_mask)
             layer_outputs.append(layer_output)
 
-        output = ModelOutput(all_outputs=[embeddings, *layer_outputs])
-
-        if torch.jit.is_tracing():
-            return output.astuple()  # type: ignore[return-value]
-        else:
-            return output
+        return ModelOutput(all_outputs=[embeddings, *layer_outputs])
 
     @classmethod
     def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):

--- a/curated_transformers/models/falcon/decoder.py
+++ b/curated_transformers/models/falcon/decoder.py
@@ -111,15 +111,10 @@ class FalconDecoder(DecoderModule, FromHFHub):
 
         layer_outputs[-1] = self.output_layer_norm(layer_outputs[-1])
 
-        output = ModelOutputWithCache(
+        return ModelOutputWithCache(
             all_outputs=[embeddings, *layer_outputs],
             cache=new_cache if store_cache else None,
         )
-
-        if torch.jit.is_tracing():
-            return output.astuple()  # type: ignore[return-value]
-        else:
-            return output
 
     @classmethod
     def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):

--- a/curated_transformers/models/gpt_neox/decoder.py
+++ b/curated_transformers/models/gpt_neox/decoder.py
@@ -138,15 +138,10 @@ class GPTNeoXDecoder(DecoderModule, FromHFHub):
 
         layer_outputs[-1] = self.output_layer_norm(layer_outputs[-1])
 
-        output = ModelOutputWithCache(
+        return ModelOutputWithCache(
             all_outputs=[embeddings, *layer_outputs],
             cache=new_cache if store_cache else None,
         )
-
-        if torch.jit.is_tracing():
-            return output.astuple()  # type: ignore[return-value]
-        else:
-            return output
 
     @classmethod
     def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):

--- a/curated_transformers/models/llama/decoder.py
+++ b/curated_transformers/models/llama/decoder.py
@@ -143,15 +143,10 @@ class LLaMADecoder(DecoderModule, FromHFHub):
 
         layer_outputs[-1] = self.output_layer_norm(layer_outputs[-1])
 
-        output = ModelOutputWithCache(
+        return ModelOutputWithCache(
             all_outputs=[embeddings, *layer_outputs],
             cache=new_cache if store_cache else None,
         )
-
-        if torch.jit.is_tracing():
-            return output.astuple()  # type: ignore[return-value]
-        else:
-            return output
 
     @classmethod
     def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):

--- a/curated_transformers/models/roberta/encoder.py
+++ b/curated_transformers/models/roberta/encoder.py
@@ -111,12 +111,7 @@ class RoBERTaEncoder(EncoderModule, FromHFHub):
             layer_output, _ = layer(layer_output, attention_mask)
             layer_outputs.append(layer_output)
 
-        output = ModelOutput(all_outputs=[embeddings, *layer_outputs])
-
-        if torch.jit.is_tracing():
-            return output.astuple()  # type: ignore[return-value]
-        else:
-            return output
+        return ModelOutput(all_outputs=[embeddings, *layer_outputs])
 
     @classmethod
     def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):

--- a/curated_transformers/tests/models/util.py
+++ b/curated_transformers/tests/models/util.py
@@ -50,9 +50,9 @@ class JITMethod(Enum):
     ]:
         with enable_torch_sdp(with_torch_sdp):
             if self == JITMethod.Disable:
-                return model, lambda s: s.astuple()
+                return model, lambda s: s
             elif self == JITMethod.TorchCompile:
-                return torch.compile(model), lambda s: s.astuple()
+                return torch.compile(model), lambda s: s
             else:
                 if isinstance(model, EncoderModule):
                     cls = ModelOutput
@@ -61,7 +61,7 @@ class JITMethod(Enum):
                 elif isinstance(model, CausalLMModule):
                     cls = ModelOutputWithCache
                 return (
-                    torch.jit.trace(model, tuple(args), strict=False),
+                    torch.jit.trace(model, tuple(args)),
                     lambda s: s,
                 )
 
@@ -152,6 +152,7 @@ def assert_decoder_output_equals_hf(
 
     X = torch.randint(0, hf_model.config.vocab_size, (2, 10), device=torch_device)
     with torch.no_grad():
+        mo = output(model(X))
         Y = output(model(X))[0][-1]
         Y_hf = hf_model(X).last_hidden_state
 

--- a/curated_transformers/util/dataclass.py
+++ b/curated_transformers/util/dataclass.py
@@ -1,5 +1,5 @@
 from dataclasses import fields
-from typing import Any, OrderedDict, Tuple
+from typing import Any, Generator, OrderedDict
 
 from torch import Tensor
 
@@ -55,9 +55,34 @@ class DataclassAsDict(OrderedDict[str, Tensor]):
         super().__setitem__(key, value)
 
 
-class DataclassAsTuple:
+class _InterceptGeneratorMeta(type):
     """
-    Dataclasses that derive from this struct can be converted to a tuple.
+    Tuples can take a generator as their only constructor argument,
+    dataclasses will see them them as a single argument. Intercept
+    single generator argument, evaluate the generator, and pass
+    the values as args.
+    """
+
+    def __new__(cls, name, bases, dict):
+        # Add tuple as a base class. MyPy complains about having tuple
+        # directly as a base class. See: https://github.com/python/mypy/issues/14818
+        return super().__new__(cls, name, bases + (tuple,), dict)
+
+    def __call__(cls, *args, **kwargs):
+        # Convert generator argument to a tuple, so that we can pass
+        # the values as regular arguments.
+        if len(args) == 1 and kwargs == {} and isinstance(args[0], Generator):
+            args = tuple(args[0])
+
+        obj = super().__call__(*args, **kwargs)
+        obj._is_frozen = True
+
+        return obj
+
+
+class DataclassAsTuple(metaclass=_InterceptGeneratorMeta):
+    """
+    Dataclasses that derive from this class are also a tuple.
 
     Since this class should only be used for dataclasses that are
     ``torch.jit.trace``-able, only the following types of fields
@@ -65,37 +90,55 @@ class DataclassAsTuple:
 
     * ``Tensor``
     * ``List[Tensor]``
-    * ``List[DataclassAsDict]``
+    * ``List[Tuple[...]]``
     * ``Optional`` of any of the above.
 
     Fields that have the value ``None`` are skipped.
     """
 
-    def astuple(self) -> Tuple:
-        to_tuples = []
-        for field in fields(self):
-            value = getattr(self, field.name)
+    def __new__(cls, *args, **kwargs):
+        values = []
+        for idx, field in enumerate(fields(cls)):
+            if idx < len(args):
+                value = args[idx]
+            elif field.name in kwargs:
+                value = kwargs[field.name]
+            else:
+                # Field is not specified, consider it optional. If it is
+                # a mandatory field, the dataclass machinery will complain
+                # later.
+                continue
+
             if value is None:
                 continue
-            elif isinstance(value, Tensor):
-                pass
-            elif isinstance(value, list):
-                if all(isinstance(item, Tensor) for item in value):
-                    value = tuple(value)
-                elif all(isinstance(item, DataclassAsDict) for item in value):
-                    value = tuple(value)
-                else:
-                    type_names = ", ".join(
-                        sorted({type(item).__name__ for item in value})
-                    )
-                    raise TypeError(
-                        f"List must be List[Tensor] or List[DataclassAsDict], found types: {type_names}"
-                    )
+
+            values.append(DataclassAsTuple._convert_value(value))
+
+        return tuple.__new__(cls, values)
+
+    @staticmethod
+    def _convert_value(value):
+        if isinstance(value, Tensor):
+            return value
+        elif isinstance(value, list):
+            if all(isinstance(item, Tensor) for item in value):
+                return tuple(value)
+            elif all(isinstance(item, tuple) for item in value):
+                return tuple(value)
             else:
+                type_names = ", ".join(sorted({type(item).__name__ for item in value}))
                 raise TypeError(
-                    f"Field '{field.name}' has unsupported type `{type(value).__name__}`"
+                    f"List must be List[Tensor] or List[Tuple[...]], found types: {type_names}"
                 )
+        else:
+            raise TypeError(f"Field has unsupported type `{type(value).__name__}`")
 
-            to_tuples.append(value)
+    def __delattr__(self, name: str):
+        if getattr(self, "_is_frozen", False):
+            raise TypeError("`AsTuple` object does not support attribute deletion")
+        super().__delattr__(name)
 
-        return tuple(to_tuples)
+    def __setattr__(self, name: str, value: Any) -> None:
+        if getattr(self, "_is_frozen", False):
+            raise TypeError("`AsTuple` object does not support attribute assignment")
+        super().__setattr__(name, value)

--- a/curated_transformers/util/dataclass.py
+++ b/curated_transformers/util/dataclass.py
@@ -128,7 +128,7 @@ class DataclassAsTuple(metaclass=_InterceptGeneratorMeta):
             else:
                 type_names = ", ".join(sorted({type(item).__name__ for item in value}))
                 raise TypeError(
-                    f"List must be List[Tensor] or List[Tuple[...]], found types: {type_names}"
+                    f"List must be `List[Tensor]` or `List[Tuple[...]]`, found types: {type_names}"
                 )
         else:
             raise TypeError(f"Field has unsupported type `{type(value).__name__}`")

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -39,23 +39,12 @@ Tensor]]`` as an ``AttentionMask``:
 Module Return Values
 """"""""""""""""""""
 
-The ``ModelOutput``-based return types can contain nested dataclasses. For 
-instance, ``ModelOutputWithCache`` contains an ``Optional[List[CacheT]]`` field where
-``CacheT`` can be ``KeyValueCache``. Consequently, not every ``ModelOutput`` can
-be represented as a ``Dict[str, Tentor]``. For that reason, we represent them as
-tuples instead. We provide a ``DataclassAsTuple`` base class that provides a method
-to convert itself into tuples. Since we don't want to return tuples for untraced
-models, each model should only return a tuple when the model is being traced:
-
-.. code-block:: python
-
-   if torch.jit.is_tracing():
-       return output.astuple()  # type: ignore[return-value]
-   else:
-       return output
-
-The type ignore is intentional since we don't want the tuple to appear in the
-return type.
+The ``ModelOutput``-based return types can contain nested dataclasses. For
+instance, ``ModelOutputWithCache`` contains an ``Optional[List[CacheT]]`` field
+where ``CacheT`` can be ``KeyValueCache``. Consequently, not every
+``ModelOutput`` can be represented as a ``Dict[str, Tentor]``. For that reason,
+we represent model outputs as tuples instead. Dataclasses that inherit from
+``DataclassAsTuple`` are also a tuple.
 
 Scripting
 ^^^^^^^^^


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Before this change, `DataclassAsTuple` provided an `astuple` method to convert the dataclass to a tuple. This change makes `DataClassAsTuple` a subclass of `tuple`, so that it can be used directly in TorchScript tracing.

This removes the need to conditionally return tuples depending on whether we are tracing.

We also make `KeyValueCache` derive from `DataclassAsTuple` rather than `DataclassAsDict`. This provides weaker guarantees in rewrapping (since) we don't get keys anymore. However, the benefit is that we can run tracing with strictness switched on (since the return value does not contain a dict).

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Enhancement?

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
