### PR TITLE
Make the attention mask a mandatory argument of models

### DIFF
--- a/curated_transformers/layers/transformer.py
+++ b/curated_transformers/layers/transformer.py
@@ -328,12 +328,12 @@ class _TransformerLayer(Module):
     def _forward(
         self,
         input: Tensor,
+        attention_mask: AttentionMask,
         *,
-        use_causal_mask: bool,
-        attention_mask: Optional[AttentionMask],
         cache: Optional[KeyValueCache] = None,
         positions: Optional[Tensor] = None,
         store_cache: bool = False,
+        use_causal_mask: bool,
     ) -> Tuple[Tensor, Optional[KeyValueCache]]:
         """
         Apply the transformer layer to the given piece hidden representations.
@@ -401,7 +401,8 @@ class DecoderLayer(_TransformerLayer):
     def forward(
         self,
         input: Tensor,
-        attention_mask: Optional[AttentionMask],
+        attention_mask: AttentionMask,
+        *,
         cache: Optional[KeyValueCache] = None,
         positions: Optional[Tensor] = None,
         store_cache: bool = False,
@@ -451,7 +452,7 @@ class EncoderLayer(_TransformerLayer):
     def forward(
         self,
         input: Tensor,
-        attention_mask: Optional[AttentionMask],
+        attention_mask: AttentionMask,
     ) -> Tuple[Tensor, Optional[KeyValueCache]]:
         """
         Apply the encoder layer to the given piece hidden representations.

--- a/curated_transformers/models/albert/encoder.py
+++ b/curated_transformers/models/albert/encoder.py
@@ -79,7 +79,7 @@ class ALBERTEncoder(EncoderModule, FromHFHub):
     def forward(
         self,
         piece_ids: Tensor,
-        attention_mask: Optional[AttentionMask] = None,
+        attention_mask: AttentionMask,
         *,
         type_ids: Optional[Tensor] = None,
         positions: Optional[Tensor] = None,

--- a/curated_transformers/models/falcon/layer.py
+++ b/curated_transformers/models/falcon/layer.py
@@ -28,7 +28,7 @@ class OldFalconDecoderLayer(Module):
         self,
         layer_config: TransformerLayerConfig,
         *,
-        device: Optional[torch.device] = None
+        device: Optional[torch.device] = None,
     ):
         super().__init__()
 
@@ -101,7 +101,8 @@ class OldFalconDecoderLayer(Module):
     def forward(
         self,
         input: Tensor,
-        attention_mask: Optional[AttentionMask],
+        attention_mask: AttentionMask,
+        *,
         cache: Optional[KeyValueCache] = None,
         positions: Optional[Tensor] = None,
         store_cache: bool = False,

--- a/curated_transformers/models/module.py
+++ b/curated_transformers/models/module.py
@@ -2,10 +2,9 @@ from abc import abstractmethod
 from typing import Generic, List, Optional
 
 from torch import Tensor
-from torch.nn import Module, ModuleList
+from torch.nn import Module
 
 from ..layers.attention import AttentionMask
-from ..layers.cache import KeyValueCache
 from .output import CacheT, CausalLMOutputWithCache, ModelOutput, ModelOutputWithCache
 
 
@@ -18,7 +17,8 @@ class CausalLMModule(Generic[CacheT], Module):
     def forward(
         self,
         piece_ids: Tensor,
-        attention_mask: Optional[AttentionMask] = None,
+        attention_mask: AttentionMask,
+        *,
         cache: Optional[List[CacheT]] = None,
         positions: Optional[Tensor] = None,
         store_cache: bool = False,
@@ -60,7 +60,8 @@ class DecoderModule(Generic[CacheT], Module):
     def forward(
         self,
         piece_ids: Tensor,
-        attention_mask: Optional[AttentionMask] = None,
+        attention_mask: AttentionMask,
+        *,
         cache: Optional[List[CacheT]] = None,
         positions: Optional[Tensor] = None,
         store_cache: bool = False,
@@ -102,7 +103,7 @@ class EncoderModule(Module):
     def forward(
         self,
         piece_ids: Tensor,
-        attention_mask: Optional[AttentionMask] = None,
+        attention_mask: AttentionMask,
         *,
         positions: Optional[Tensor] = None,
         type_ids: Optional[Tensor] = None,

--- a/curated_transformers/models/transformer.py
+++ b/curated_transformers/models/transformer.py
@@ -27,7 +27,8 @@ class TransformerDecoder(DecoderModule):
     def forward(
         self,
         piece_ids: Tensor,
-        attention_mask: Optional[AttentionMask] = None,
+        attention_mask: AttentionMask,
+        *,
         cache: Optional[List[KeyValueCache]] = None,
         positions: Optional[Tensor] = None,
         store_cache: bool = False,
@@ -79,7 +80,7 @@ class TransformerCausalLM(CausalLMModule[KeyValueCache]):
     def forward(
         self,
         piece_ids: Tensor,
-        attention_mask: Optional[AttentionMask] = None,
+        attention_mask: AttentionMask,
         cache: Optional[List[KeyValueCache]] = None,
         positions: Optional[Tensor] = None,
         store_cache: bool = False,
@@ -119,7 +120,7 @@ class TransformerEncoder(EncoderModule):
     def forward(
         self,
         piece_ids: Tensor,
-        attention_mask: Optional[AttentionMask] = None,
+        attention_mask: AttentionMask,
         *,
         positions: Optional[Tensor] = None,
         type_ids: Optional[Tensor] = None,

--- a/curated_transformers/tests/layers/test_attention.py
+++ b/curated_transformers/tests/layers/test_attention.py
@@ -45,10 +45,11 @@ def test_torch_sdp(torch_device):
 
     torch.manual_seed(0)
     X = torch.randint(0, N_PIECES, (2, 10), device=torch_device)
+    mask = torch.ones_like(X, dtype=torch.bool)
     with torch.no_grad():
-        Y = model(X).last_hidden_layer_state
+        Y = model(X, AttentionMask(mask)).last_hidden_layer_state
         with enable_torch_sdp():
-            Y_sdp = model(X).last_hidden_layer_state
+            Y_sdp = model(X, AttentionMask(mask)).last_hidden_layer_state
     torch_assertclose(Y, Y_sdp)
 
 
@@ -84,10 +85,11 @@ def test_torch_sdp_causal(torch_device):
 
     torch.manual_seed(0)
     X = torch.randint(0, N_PIECES, (2, 10), device=torch_device)
+    mask = torch.ones_like(X, dtype=torch.bool)
     with torch.no_grad():
-        Y = model(X).last_hidden_layer_state
+        Y = model(X, AttentionMask(mask)).last_hidden_layer_state
         with enable_torch_sdp():
-            Y_sdp = model(X).last_hidden_layer_state
+            Y_sdp = model(X, AttentionMask(mask)).last_hidden_layer_state
     torch_assertclose(Y, Y_sdp)
 
 

--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -36,16 +36,18 @@ inputs as a tuple. For example, we can trace a decoder as follows:
 
    import torch
    import torch.jit
+   from curated_transformers.layers import AttentionMask
    from curated_transformers.models import AutoDecoder
 
    device = torch.device("cuda", index=0)
    decoder = AutoDecoder.from_hf_hub(name="tiiuae/falcon-7b", device=device)
    X_example = torch.zeros(4, 20, dtype=torch.long, device=device)
-   traced = torch.jit.trace(decoder, (X_example),))
+   mask_example = AttentionMask(torch.ones((4, 20), dtype=torch.bool, device=device))
+   traced = torch.jit.trace(decoder, (X_example, mask_example))
 
-As you can see, we are feeding the model with an all-zeros tensor during
-tracing. This is not really an issue, as long as the inputs allows the model to
-run normally, tracing can do its work.
+As you can see, we are feeding the model with an all-zeros piece identifier and
+all-ones mask tensors during tracing. This is not really an issue, as long as
+the inputs allows the model to run normally, tracing can do its work.
 
 In the example above, ``traced`` is a TorchScript module. From the surface, it
 behaves like any other module. We can feed it some piece identifiers to get
@@ -57,7 +59,8 @@ their hidden representations:
 
    tokenizer = AutoTokenizer.from_hf_hub(name="tiiuae/falcon-7b")
    pieces = tokenizer(["Hello world!", "This is a test"])
-   Y = traced(pieces.padded_tensor(device=device))
+   Y = traced(pieces.padded_tensor(device=device),
+              pieces.attention_mask(device=device))
    assert isinstance(Y, tuple)
    last_layer = Y[0][-1]
 
@@ -70,21 +73,6 @@ instance to a tuple in a traced model. The tuple will have the same ordering as 
 fields in the untraced model's output, excluding fields that are set to
 ``None``. In this case we don't ask the decoder to return a key-value cache, so
 the ``cache`` field is ``None`` and will not be represented in the tuple.
-
-The example above does not compute the correct outputs yet. Since the input sequences
-have different lengths, we also have to provide the model an attention mask to
-prevent it from attending to padding pieces. This is a fairly straightforward
-fix — since the attention mask is the second argument to the model, we'll
-retrace the model with a dummy attention mask:
-
-.. code-block:: python
-
-   from curated_transformers.layers.attention import AttentionMask
-
-   mask_example = AttentionMask(torch.ones((4, 20), dtype=torch.bool, device=device))
-   traced = torch.jit.trace(decoder, (X_example, mask_example,))
-   Y = traced(pieces.padded_tensor(device=device),
-              pieces.attention_mask(device=device))
 
 Handling Complex Model Signatures
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -111,8 +99,11 @@ class ``DecoderWithPositions``:
            super().__init__()
            self.inner = decoder
 
-       def forward(self, input_ids: Tensor, positions: Tensor):
-           return self.inner.forward(input_ids=input_ids, positions=positions)
+       def forward(self,
+                   input_ids: Tensor,
+                   attention_mask: AttentionMask,
+                   positions: Tensor):
+           return self.inner.forward(input_ids, attention_mask, positions=positions)
 
 You can then wrap a decoder with this class and trace it using the two mandatory
 arguments.

--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -45,9 +45,9 @@ inputs as a tuple. For example, we can trace a decoder as follows:
    mask_example = AttentionMask(torch.ones((4, 20), dtype=torch.bool, device=device))
    traced = torch.jit.trace(decoder, (X_example, mask_example))
 
-As you can see, we are feeding the model with an all-zeros piece identifier and
-all-ones mask tensors during tracing. This is not really an issue, as long as
-the inputs allows the model to run normally, tracing can do its work.
+As you can see, we are feeding the model with an all-zeros piece identifier tensor and
+an all-ones mask tensor during tracing. This is not really an issue - as long as
+the inputs allow the model to run normally, tracing can do its work.
 
 In the example above, ``traced`` is a TorchScript module. From the surface, it
 behaves like any other module. We can feed it some piece identifiers to get

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -202,7 +202,8 @@ In addition to text generation, one can also run inference on the inputs to prod
    # Don't allocate gradients since we're only running inference.
    with torch.no_grad():
       ids = input_pieces.padded_tensor(pad_left=True, device=device)
-      model_output = encoder(input_ids=ids)
+      attention_mask = input_pieces.attention_mask(device=device)
+      model_output = encoder(ids, attention_mask)
 
    # [batch, seq_len, width]
    last_hidden_repr = model_output.last_hidden_layer_state


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

It is very easy to forget to pass the attention mask, giving bad output.
On the other hand it is very unlikely that someone doesn't want to use
an attention mask. In such cases, it is always possible to create a
custom mask all elements set to `True`.

While at it, also consistently make `piece_ids`/`attention_mask`
positional arguments, while making all other arguments kwarg-only.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.