### PR TITLE
Add support for `safetensors` checkpoints

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,5 +99,10 @@ jobs:
         run: |
           python -m pip install sentencepiece
 
+      # For testing safetensor checkpoints.
+      - name: Install safetensors
+        run: |
+          python -m pip install safetensors
+
       - name: Run pytest (w/t HF transformers)
         run: python -m pytest --pyargs curated_transformers

--- a/curated_transformers/_compat.py
+++ b/curated_transformers/_compat.py
@@ -14,3 +14,5 @@ if has_bitsandbytes and not _has_scipy:
         "`scipy` isn't. Please install `scipy` to correctly load `bitsandbytes`."
     )
     has_bitsandbytes = False
+
+has_safetensors = find_spec("safetensors")

--- a/curated_transformers/models/hf_hub.py
+++ b/curated_transformers/models/hf_hub.py
@@ -137,10 +137,11 @@ class FromHFHub(ABC):
             tensor2param = None
 
         # Download model and convert HF parameter names to ours.
-        checkpoint_filenames = get_model_checkpoint_filepaths(name, revision)
+        checkpoint_filenames, checkpoint_type = get_model_checkpoint_filepaths(name, revision)
         load_model_from_checkpoints(
             model,  # type:ignore
             filepaths=checkpoint_filenames,
+            checkpoint_type=checkpoint_type,
             state_dict_converter=cls.convert_hf_state_dict,
             tensor_to_param_converter=tensor2param,
             device=device,

--- a/curated_transformers/tests/compat.py
+++ b/curated_transformers/tests/compat.py
@@ -16,3 +16,11 @@ if has_torch_compile:
         torch.compile(Identity(), disable=True)
     except:
         has_torch_compile = False
+
+try:
+    import safetensors
+
+    has_safetensors = True
+except ImportError:
+    safetensors = None  # type: ignore
+    has_safetensors = False

--- a/curated_transformers/util/__init__.py
+++ b/curated_transformers/util/__init__.py
@@ -1,1 +1,1 @@
-
+from .serde import ModelCheckpointType, use_model_checkpoint_type

--- a/curated_transformers/util/hf.py
+++ b/curated_transformers/util/hf.py
@@ -1,13 +1,18 @@
 import json
 import warnings
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import huggingface_hub
 from requests import HTTPError, ReadTimeout  # type: ignore
 
+from .._compat import has_safetensors
+from .serde import MODEL_CHECKPOINT_TYPE, ModelCheckpointType
+
 HF_MODEL_CONFIG = "config.json"
 HF_MODEL_CHECKPOINT = "pytorch_model.bin"
+HF_MODEL_CHECKPOINT_SAFETENSORS = "model.safetensors"
 HF_MODEL_SHARDED_CHECKPOINT_INDEX = "pytorch_model.bin.index.json"
+HF_MODEL_SHARDED_CHECKPOINT_INDEX_SAFETENSORS = "model.safetensors.index.json"
 HF_MODEL_SHARDED_CHECKPOINT_INDEX_WEIGHTS_KEY = "weight_map"
 HF_TOKENIZER_CONFIG = "tokenizer_config.json"
 SPECIAL_TOKENS_MAP = "special_tokens_map.json"
@@ -73,11 +78,13 @@ def get_model_config_filepath(name: str, revision: str) -> str:
         )
 
 
-def get_model_checkpoint_filepaths(name: str, revision: str) -> List[str]:
+def get_model_checkpoint_filepaths(
+    name: str, revision: str
+) -> Tuple[List[str], ModelCheckpointType]:
     """
-    Return a list of local file paths to PyTorch checkpoints that belong
-    to the Hugging Face model. In case of non-sharded models, a single file path
-    is returned. In case of sharded models, multiple file paths are returned.
+    Return a list of local file paths to  checkpoints that belong to the Hugging
+    Face model. In case of non-sharded models, a single file path is returned. In
+    case of sharded models, multiple file paths are returned.
 
     If the checkpoints are not found in the cache, they are downloaded from
     Hugging Face Hub.
@@ -87,50 +94,98 @@ def get_model_checkpoint_filepaths(name: str, revision: str) -> List[str]:
     :param revision:
         Model revision.
     :returns:
-        List of absolute paths to the checkpoints.
+        List of absolute paths to the checkpoints
+        and the checkpoint type.
     """
 
-    # Attempt to download a non-sharded checkpoint first.
-    try:
-        model_filename = hf_hub_download(
-            repo_id=name, filename=HF_MODEL_CHECKPOINT, revision=revision
-        )
-    except HTTPError:
-        # We'll get a 404 HTTP error for sharded models.
-        model_filename = None
+    def get_checkpoint_paths(
+        checkpoint_type: ModelCheckpointType,
+    ) -> List[str]:
+        checkpoint_type_to_string = {
+            ModelCheckpointType.PYTORCH: "PyTorch",
+            ModelCheckpointType.SAFETENSORS: "Safetensors",
+        }
 
-    if model_filename is not None:
-        return [model_filename]
-
-    try:
-        model_index_filename = hf_hub_download(
-            repo_id=name, filename=HF_MODEL_SHARDED_CHECKPOINT_INDEX, revision=revision
-        )
-    except HTTPError:
-        raise ValueError(
-            f"Couldn't find a valid PyTorch checkpoint for model `{name}` "
-            f"(revision `{revision}`) on HuggingFace Model Hub"
-        )
-
-    with open(model_index_filename, "r") as f:
-        index = json.load(f)
-
-    weight_map = index.get(HF_MODEL_SHARDED_CHECKPOINT_INDEX_WEIGHTS_KEY)
-    if weight_map is None or not isinstance(weight_map, dict):
-        raise ValueError(
-            f"Invalid index file in sharded PyTorch checkpoint for model `{name}`"
+        primary_checkpoint_filenames = {
+            ModelCheckpointType.PYTORCH: HF_MODEL_CHECKPOINT,
+            ModelCheckpointType.SAFETENSORS: HF_MODEL_CHECKPOINT_SAFETENSORS,
+        }
+        sharded_checkpoint_index_filenames = {
+            ModelCheckpointType.PYTORCH: HF_MODEL_SHARDED_CHECKPOINT_INDEX,
+            ModelCheckpointType.SAFETENSORS: HF_MODEL_SHARDED_CHECKPOINT_INDEX_SAFETENSORS,
+        }
+        # Same for both checkpoint types.
+        sharded_checkpoint_index_weights_key = (
+            HF_MODEL_SHARDED_CHECKPOINT_INDEX_WEIGHTS_KEY
         )
 
-    filepaths = []
-    # We shouldn't need to hold on to the weights map in the index as each checkpoint
-    # should contain its constituent parameter names.
-    for filename in set(weight_map.values()):
-        resolved_filename = hf_hub_download(
-            repo_id=name, filename=filename, revision=revision
-        )
-        filepaths.append(resolved_filename)
+        # Attempt to download a non-sharded checkpoint first.
+        try:
+            model_filename = hf_hub_download(
+                repo_id=name,
+                filename=primary_checkpoint_filenames[checkpoint_type],
+                revision=revision,
+            )
+        except HTTPError:
+            # We'll get a 404 HTTP error for sharded models.
+            model_filename = None
 
-    return sorted(filepaths)
+        if model_filename is not None:
+            return [model_filename]
+
+        try:
+            model_index_filename = hf_hub_download(
+                repo_id=name,
+                filename=sharded_checkpoint_index_filenames[checkpoint_type],
+                revision=revision,
+            )
+        except HTTPError:
+            raise ValueError(
+                f"Couldn't find a valid {checkpoint_type_to_string[checkpoint_type]} "
+                f"checkpoint for model `{name}` (revision `{revision}`) on HuggingFace Model Hub"
+            )
+
+        with open(model_index_filename, "r") as f:
+            index = json.load(f)
+
+        weight_map = index.get(sharded_checkpoint_index_weights_key)
+        if weight_map is None or not isinstance(weight_map, dict):
+            raise ValueError(
+                f"Invalid index file in sharded {checkpoint_type_to_string[checkpoint_type]} "
+                f"checkpoint for model `{name}`"
+            )
+
+        filepaths = []
+        # We shouldn't need to hold on to the weights map in the index as each checkpoint
+        # should contain its constituent parameter names.
+        for filename in set(weight_map.values()):
+            resolved_filename = hf_hub_download(
+                repo_id=name, filename=filename, revision=revision
+            )
+            filepaths.append(resolved_filename)
+
+        return sorted(filepaths)
+
+    checkpoint_type = MODEL_CHECKPOINT_TYPE.get()
+    checkpoint_paths: Optional[List[str]] = None
+
+    if checkpoint_type is None:
+        # Precedence: Safetensors > PyTorch
+        if has_safetensors:
+            try:
+                checkpoint_type = ModelCheckpointType.SAFETENSORS
+                checkpoint_paths = get_checkpoint_paths(checkpoint_type)
+            except ValueError:
+                pass
+        if checkpoint_paths is None:
+            checkpoint_type = ModelCheckpointType.PYTORCH
+            checkpoint_paths = get_checkpoint_paths(checkpoint_type)
+    else:
+        checkpoint_paths = get_checkpoint_paths(checkpoint_type)
+
+    assert checkpoint_paths is not None
+    assert checkpoint_type is not None
+    return checkpoint_paths, checkpoint_type
 
 
 def get_special_piece(

--- a/curated_transformers/util/serde.py
+++ b/curated_transformers/util/serde.py
@@ -1,9 +1,25 @@
-from typing import Callable, Dict, Iterable, Mapping, Optional, Set, Union
+from contextlib import contextmanager
+from contextvars import ContextVar
+from enum import Enum
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    Iterable,
+    Mapping,
+    Optional,
+    Set,
+    Union,
+)
 
 import torch
 from torch.nn import Module, Parameter
 
+from .._compat import has_safetensors
 from .pytorch import ModuleIterator, apply_to_module
+
+if TYPE_CHECKING:
+    import safetensors
 
 # Args: Parent module, module prefix, parameter name, tensor to convert, device.
 # Returns the new paramater.
@@ -18,10 +34,52 @@ HFStateDictConverterT = Callable[
 ]
 
 
+class ModelCheckpointType(Enum):
+    """
+    Types of model checkpoints supported by Curated Transformers.
+    """
+
+    #: PyTorch checkpoint.
+    PYTORCH = 1
+
+    #: Hugging Face `Safetensors <https://github.com/huggingface/safetensors>`_ checkpoint.
+    SAFETENSORS = 2
+
+
+# When `None`, behaviour is implementation-specific.
+MODEL_CHECKPOINT_TYPE: ContextVar[Optional[ModelCheckpointType]] = ContextVar(
+    "model_checkpoint_type", default=None
+)
+
+
+@contextmanager
+def use_model_checkpoint_type(
+    model_checkpoint_type: ModelCheckpointType,
+):
+    """
+    Specifies which type of model checkpoint to use when loading a serialized model.
+
+    By default, Curated Transformers will attempt to load from the most suitable
+    checkpoint type depending on its availability. This context manager can be used
+    to override the default behaviour.
+
+    .. code-block:: python
+
+        with use_model_checkpoint_type(ModelCheckpointType.SAFETENSORS):
+            encoder = BertEncoder.from_hf_hub(name="bert-base-uncased")
+    """
+    token = MODEL_CHECKPOINT_TYPE.set(model_checkpoint_type)
+    try:
+        yield
+    finally:
+        MODEL_CHECKPOINT_TYPE.reset(token)
+
+
 def load_model_from_checkpoints(
     model: Module,
     *,
     filepaths: Iterable[str],
+    checkpoint_type: ModelCheckpointType,
     state_dict_converter: HFStateDictConverterT,
     tensor_to_param_converter: Optional[TensorToParameterConverterT] = None,
     device: Optional[torch.device] = None,
@@ -33,16 +91,23 @@ def load_model_from_checkpoints(
         PyTorch module into which the parameters are to be loaded.
     :param filepaths:
         Paths to PyTorch checkpoints.
+    :param checkpoint_type:
+        Type of checkpoint being loaded.
     :param state_dict_converter:
         Callback to convert Hugging Face state dicts to the
-        `curated-transformers` format.
+        ``curated-transformers`` format.
     :param tensor_to_param_converter:
         Callback to perform custom conversions of the loaded parameters.
         Useful for loading quantized weights.
     :param device:
         Device in which to place the loaded parameters.
     """
-    state_dicts = _load_state_dicts_from_checkpoints(filepaths)
+    checkpoint_type_to_loader = {
+        ModelCheckpointType.PYTORCH: _load_pytorch_state_dicts_from_checkpoints,
+        ModelCheckpointType.SAFETENSORS: _load_safetensor_state_dicts_from_checkpoints,
+    }
+
+    state_dicts = checkpoint_type_to_loader[checkpoint_type](filepaths)
     # We need to cache the model's parameter keys before loading the state
     # dicts as the process could potentially change the structure of sub-modules,
     # e.g: when quantized layers rename their parameters.
@@ -97,17 +162,6 @@ def default_tensor_to_parameter_converter(
     assert old_param is not None
     _validate_replacement(old_param, tensor, module_prefix)
     return Parameter(tensor, requires_grad=old_param.requires_grad).to(device=device)  # type: ignore
-
-
-def _load_state_dicts_from_checkpoints(
-    filepaths: Iterable[str],
-) -> Iterable[Mapping[str, torch.Tensor]]:
-    for path in filepaths:
-        # Map to CPU first to support all devices.
-        state_dict = torch.load(
-            path, map_location=torch.device("cpu"), weights_only=True
-        )
-        yield state_dict
 
 
 def _emplace_module_state_dict(
@@ -208,3 +262,30 @@ def _validate_replacement(
         raise ValueError(
             f"Expected dtype of replacement for `{name}` to be {replaced.dtype}, but got {replacement.dtype}"
         )
+
+
+def _load_safetensor_state_dicts_from_checkpoints(
+    filepaths: Iterable[str],
+) -> Iterable[Mapping[str, torch.Tensor]]:
+    if not has_safetensors:
+        raise ValueError(
+            "The `safetensors` library is required to load models from Safetensors checkpoints"
+        )
+
+    import safetensors
+
+    for path in filepaths:
+        # Map to CPU first to support all devices.
+        state_dict = safetensors.torch.load_file(path, device="cpu")
+        yield state_dict
+
+
+def _load_pytorch_state_dicts_from_checkpoints(
+    filepaths: Iterable[str],
+) -> Iterable[Mapping[str, torch.Tensor]]:
+    for path in filepaths:
+        # Map to CPU first to support all devices.
+        state_dict = torch.load(
+            path, map_location=torch.device("cpu"), weights_only=True
+        )
+        yield state_dict

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -1,10 +1,18 @@
 Utilities
 =========
 
+Serialization
+-------------
+
+.. autoclass:: curated_transformers.util.ModelCheckpointType
+   :members:
+
 Context Managers
 ----------------
 
 .. autofunction:: curated_transformers.layers.attention.enable_torch_sdp
+
+.. autofunction:: curated_transformers.util.use_model_checkpoint_type
 
 Hugging Face
 ------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
This PR introduces support for model checkpoints that saved in the `safetensors` serialization format. `FromHFHub` mixins will prefer to initialize models from `safetensors` checkpoints if the following conditions are met:
- The `safetensors` library is installed.
- The model repo contains `.safetensors` checkpoint files.

If one of the above conditions are not met, the loader will fallback to using regular PyTorch checkpoints. This also applies to sharded checkpoints.

Additionally, the user can force the usage of a specific checkpoint type with the `use_model_checkpoint_type` context manager. 

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [X] I confirm that I have the right to submit this contribution under the project's MIT license.
