### PR TITLE
Add optional NVTX ranges annotations for forward passes

### DIFF
--- a/curated_transformers/util/__init__.py
+++ b/curated_transformers/util/__init__.py
@@ -1,0 +1,1 @@
+from .profile import use_nvtx_ranges_for_forward_pass

--- a/curated_transformers/util/profile.py
+++ b/curated_transformers/util/profile.py
@@ -1,0 +1,49 @@
+import functools
+from contextlib import contextmanager
+from typing import List
+
+import torch
+from torch.nn import Module
+from torch.utils.hooks import RemovableHandle
+
+from .pytorch import ModuleIterator, apply_to_module
+
+
+@contextmanager
+def use_nvtx_ranges_for_forward_pass(module: Module):
+    """
+    Recursively applies `NVTX ranges`_ to the forward pass operation
+    of the provided module. The ranges will be recorded during an `Nsight`_
+    profiling session.
+
+    :param module:
+        Top-level module to which the ranges are applied recursively.
+
+    .. _Nsight: https://developer.nvidia.com/nsight-systems
+    .. _NVTX ranges: https://pytorch.org/docs/stable/cuda.html#nvidia-tools-extension-nvtx
+    """
+
+    hooks: List[RemovableHandle] = []
+
+    def hook_forward(itr: ModuleIterator):
+        range_name = f"{itr.name} : {type(itr.module).__name__}"
+
+        def push(*args, _range_name: str, **kwargs):
+            torch.cuda.nvtx.range_push(_range_name)
+
+        def pop(*args, **kwargs):
+            torch.cuda.nvtx.range_pop()
+
+        forward_pre = itr.module.register_forward_pre_hook(
+            functools.partial(push, _range_name=range_name)
+        )
+        forward_post = itr.module.register_forward_hook(pop)
+        hooks.append(forward_pre)
+        hooks.append(forward_post)
+
+    try:
+        apply_to_module(module, hook_forward)
+        yield
+    finally:
+        for hook in hooks:
+            hook.remove()

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -6,6 +6,8 @@ Context Managers
 
 .. autofunction:: curated_transformers.layers.enable_torch_sdp
 
+.. autofunction:: curated_transformers.util.use_nvtx_ranges_for_forward_pass
+
 Hugging Face
 ------------
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
This PR introduces `use_nvtx_ranges_for_forward_pass`, a context manager that uses `Module` hooking to instrument the forward pass invocations with NVTX ranges code. 

![Screenshot_20230911_175954](https://github.com/explosion/curated-transformers/assets/214450/b394ce12-703d-4c2e-bf2b-8540c87835ff)


## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
