### PR TITLE
Add support for converting Curated Transfomer state dicts Hugging Face compatible state dicts

### DIFF
--- a/curated_transformers/models/albert/_hf.py
+++ b/curated_transformers/models/albert/_hf.py
@@ -18,19 +18,15 @@ HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
         (r"^albert_layer_groups\.", "groups."), (r"^groups\.", "albert_layer_groups.")
     ),
     # Inner layers.
-    StringTransformations.regex_sub_invertible((".albert_layers.", ".group_layers.")),
+    StringTransformations.sub(".albert_layers.", ".group_layers."),
     # Attention blocks.
-    StringTransformations.regex_sub_invertible((".attention.", ".mha.")),
-    StringTransformations.regex_sub_invertible(
-        (".mha.LayerNorm", ".attn_residual_layer_norm")
-    ),
-    StringTransformations.regex_sub_invertible((".mha.dense", ".mha.output")),
+    StringTransformations.sub(".attention.", ".mha."),
+    StringTransformations.sub(".mha.LayerNorm", ".attn_residual_layer_norm"),
+    StringTransformations.sub(".mha.dense", ".mha.output"),
     # Pointwise feed-forward layers.
-    StringTransformations.regex_sub_invertible((".ffn.", ".ffn.intermediate.")),
-    StringTransformations.regex_sub_invertible((".ffn_output.", ".ffn.output.")),
-    StringTransformations.regex_sub_invertible(
-        (".full_layer_layer_norm.", ".ffn_residual_layer_norm.")
-    ),
+    StringTransformations.sub(".ffn.", ".ffn.intermediate."),
+    StringTransformations.sub(".ffn_output.", ".ffn.output."),
+    StringTransformations.sub(".full_layer_layer_norm.", ".ffn_residual_layer_norm."),
     # Embeddings.
     StringTransformations.replace(
         "embeddings.word_embeddings.weight", "embeddings.piece_embeddings.weight"

--- a/curated_transformers/models/albert/_hf.py
+++ b/curated_transformers/models/albert/_hf.py
@@ -1,45 +1,57 @@
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 from ...layers.activations import Activation
-from ...util.string import StringTransform, StrLStrip, StrRepl, StrSub, StrSubInv
+from ...util.string import (
+    StringRemovePrefix,
+    StringReplace,
+    StringSubInvertible,
+    StringSubRegEx,
+    StringTransform,
+)
 from ..hf_hub.conversion import process_hf_keys
 from .config import ALBERTConfig
 
 # Order-dependent.
 HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
     # Prefixes.
-    StrLStrip("albert.", reversible=False),
-    StrSub(
+    StringRemovePrefix("albert.", reversible=False),
+    StringSubRegEx(
         (r"^encoder\.(embedding_|albert_layer)", "\\1"),
         (r"^(embedding_|albert_layer)", "encoder.\\1"),
     ),
     # Layer groups
-    StrSub(
+    StringSubRegEx(
         (r"^albert_layer_groups\.", "groups."), (r"^groups\.", "albert_layer_groups.")
     ),
     # Inner layers.
-    StrSubInv((".albert_layers.", ".group_layers.")),
+    StringSubInvertible((".albert_layers.", ".group_layers.")),
     # Attention blocks.
-    StrSubInv((".attention.", ".mha.")),
-    StrSubInv((".mha.LayerNorm", ".attn_residual_layer_norm")),
-    StrSubInv((".mha.dense", ".mha.output")),
+    StringSubInvertible((".attention.", ".mha.")),
+    StringSubInvertible((".mha.LayerNorm", ".attn_residual_layer_norm")),
+    StringSubInvertible((".mha.dense", ".mha.output")),
     # Pointwise feed-forward layers.
-    StrSubInv((".ffn.", ".ffn.intermediate.")),
-    StrSubInv((".ffn_output.", ".ffn.output.")),
-    StrSubInv((".full_layer_layer_norm.", ".ffn_residual_layer_norm.")),
+    StringSubInvertible((".ffn.", ".ffn.intermediate.")),
+    StringSubInvertible((".ffn_output.", ".ffn.output.")),
+    StringSubInvertible((".full_layer_layer_norm.", ".ffn_residual_layer_norm.")),
     # Embeddings.
-    StrRepl("embeddings.word_embeddings.weight", "embeddings.piece_embeddings.weight"),
-    StrRepl(
+    StringReplace(
+        "embeddings.word_embeddings.weight", "embeddings.piece_embeddings.weight"
+    ),
+    StringReplace(
         "embeddings.token_type_embeddings.weight", "embeddings.type_embeddings.weight"
     ),
-    StrRepl(
+    StringReplace(
         "embeddings.position_embeddings.weight", "embeddings.position_embeddings.weight"
     ),
-    StrRepl("embeddings.LayerNorm.weight", "embeddings.embed_output_layer_norm.weight"),
-    StrRepl("embeddings.LayerNorm.bias", "embeddings.embed_output_layer_norm.bias"),
+    StringReplace(
+        "embeddings.LayerNorm.weight", "embeddings.embed_output_layer_norm.weight"
+    ),
+    StringReplace(
+        "embeddings.LayerNorm.bias", "embeddings.embed_output_layer_norm.bias"
+    ),
     # Embedding projection.
-    StrRepl("embedding_hidden_mapping_in.weight", "embeddings.projection.weight"),
-    StrRepl("embedding_hidden_mapping_in.bias", "embeddings.projection.bias"),
+    StringReplace("embedding_hidden_mapping_in.weight", "embeddings.projection.weight"),
+    StringReplace("embedding_hidden_mapping_in.bias", "embeddings.projection.bias"),
 ]
 
 HF_CONFIG_KEY_MAPPING: Dict[str, Union[str, Tuple[str, Callable]]] = {

--- a/curated_transformers/models/albert/_hf.py
+++ b/curated_transformers/models/albert/_hf.py
@@ -1,25 +1,46 @@
-import re
-from types import MappingProxyType
-from typing import Any, Callable, Dict, Mapping, Tuple, Union
-
-from torch import Tensor
+from typing import Any, Callable, Dict, List, Tuple, Union
 
 from ...layers.activations import Activation
-from ..hf_hub import _process_hf_keys
+from ...util.string import StringTransform, StrLStrip, StrRepl, StrSub, StrSubInv
+from ..hf_hub.conversion import process_hf_keys
 from .config import ALBERTConfig
 
-HF_KEY_TO_CURATED_KEY = MappingProxyType(
-    {
-        "embeddings.word_embeddings.weight": "embeddings.piece_embeddings.weight",
-        "embeddings.token_type_embeddings.weight": "embeddings.type_embeddings.weight",
-        "embeddings.position_embeddings.weight": "embeddings.position_embeddings.weight",
-        "embeddings.LayerNorm.weight": "embeddings.embed_output_layer_norm.weight",
-        "embeddings.LayerNorm.bias": "embeddings.embed_output_layer_norm.bias",
-        # Embedding projection
-        "encoder.embedding_hidden_mapping_in.weight": "embeddings.projection.weight",
-        "encoder.embedding_hidden_mapping_in.bias": "embeddings.projection.bias",
-    }
-)
+# Order-dependent.
+HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
+    # Prefixes.
+    StrLStrip("albert.", reversible=False),
+    StrSub(
+        (r"^encoder\.(embedding_|albert_layer)", "\\1"),
+        (r"^(embedding_|albert_layer)", "encoder.\\1"),
+    ),
+    # Layer groups
+    StrSub(
+        (r"^albert_layer_groups\.", "groups."), (r"^groups\.", "albert_layer_groups.")
+    ),
+    # Inner layers.
+    StrSubInv((".albert_layers.", ".group_layers.")),
+    # Attention blocks.
+    StrSubInv((".attention.", ".mha.")),
+    StrSubInv((".mha.LayerNorm", ".attn_residual_layer_norm")),
+    StrSubInv((".mha.dense", ".mha.output")),
+    # Pointwise feed-forward layers.
+    StrSubInv((".ffn.", ".ffn.intermediate.")),
+    StrSubInv((".ffn_output.", ".ffn.output.")),
+    StrSubInv((".full_layer_layer_norm.", ".ffn_residual_layer_norm.")),
+    # Embeddings.
+    StrRepl("embeddings.word_embeddings.weight", "embeddings.piece_embeddings.weight"),
+    StrRepl(
+        "embeddings.token_type_embeddings.weight", "embeddings.type_embeddings.weight"
+    ),
+    StrRepl(
+        "embeddings.position_embeddings.weight", "embeddings.position_embeddings.weight"
+    ),
+    StrRepl("embeddings.LayerNorm.weight", "embeddings.embed_output_layer_norm.weight"),
+    StrRepl("embeddings.LayerNorm.bias", "embeddings.embed_output_layer_norm.bias"),
+    # Embedding projection.
+    StrRepl("embedding_hidden_mapping_in.weight", "embeddings.projection.weight"),
+    StrRepl("embedding_hidden_mapping_in.bias", "embeddings.projection.bias"),
+]
 
 HF_CONFIG_KEY_MAPPING: Dict[str, Union[str, Tuple[str, Callable]]] = {
     "attention_probs_dropout_prob": "attention_probs_dropout_prob",
@@ -40,55 +61,5 @@ HF_CONFIG_KEY_MAPPING: Dict[str, Union[str, Tuple[str, Callable]]] = {
 
 
 def convert_hf_config(hf_config: Any) -> ALBERTConfig:
-    kwargs = _process_hf_keys("ALBERT", hf_config, HF_CONFIG_KEY_MAPPING)
+    kwargs = process_hf_keys("ALBERT", hf_config, HF_CONFIG_KEY_MAPPING)
     return ALBERTConfig(model_max_length=hf_config["max_position_embeddings"], **kwargs)
-
-
-def convert_hf_state_dict(params: Mapping[str, Tensor]) -> Mapping[str, Tensor]:
-    # Strip the `albert` prefix from ALBERT model parameters.
-    stripped_params = {re.sub(r"^albert\.", "", k): v for k, v in params.items()}
-
-    # The ALBERT encoder parameters have the following form:
-    #
-    # encoder.albert_layer_groups.{hidden_group}.albert_layers.{inner_layer}.{param_name}
-    #
-    # hidden_group is in [0, n_hidden_group)
-    # inner_layer is in [0, n_layers_per_group)
-
-    out = {}
-    for name, parameter in stripped_params.items():
-        if "encoder.albert_layer" not in name:
-            continue
-
-        # TODO: Make these substitutions less ugly.
-
-        # Remove the prefix and rename.
-        name = re.sub(r"^encoder\.", "", name)
-
-        # Layer groups
-        name = re.sub(r"^albert_layer_groups\.", "groups.", name)
-
-        # Inner layers.
-        name = re.sub(r"\.albert_layers\.", ".group_layers.", name)
-
-        # Attention blocks.
-        name = re.sub(r"\.attention\.", ".mha.", name)
-        name = re.sub(r"\.mha\.LayerNorm", r".attn_residual_layer_norm", name)
-        name = re.sub(r"\.mha\.dense\.", r".mha.output.", name)
-
-        # Pointwise feed-forward layers.
-        name = re.sub(r"\.ffn\.", r".ffn.intermediate.", name)
-        name = re.sub(r"\.ffn_output\.", r".ffn.output.", name)
-        name = re.sub(
-            r"\.full_layer_layer_norm\.",
-            r".ffn_residual_layer_norm.",
-            name,
-        )
-
-        out[name] = parameter
-
-    for hf_name, curated_name in HF_KEY_TO_CURATED_KEY.items():
-        if hf_name in stripped_params:
-            out[curated_name] = stripped_params[hf_name]
-
-    return out

--- a/curated_transformers/models/albert/encoder.py
+++ b/curated_transformers/models/albert/encoder.py
@@ -11,9 +11,10 @@ from ...layers.transformer import (
     TransformerEmbeddings,
 )
 from ..hf_hub import FromHFHub
+from ..hf_hub.conversion import state_dict_from_hf, state_dict_to_hf
 from ..module import EncoderModule
 from ..output import ModelOutput
-from ._hf import convert_hf_config, convert_hf_state_dict
+from ._hf import HF_PARAM_KEY_TRANSFORMS, convert_hf_config
 from .config import ALBERTConfig
 from .layer_group import ALBERTLayerGroup
 
@@ -99,8 +100,16 @@ class ALBERTEncoder(EncoderModule[ALBERTConfig], FromHFHub):
         return ModelOutput(all_outputs=[embeddings, *layer_outputs])
 
     @classmethod
-    def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):
-        return convert_hf_state_dict(params)
+    def state_dict_from_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_from_hf(params, HF_PARAM_KEY_TRANSFORMS)
+
+    @classmethod
+    def state_dict_to_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_to_hf(params, HF_PARAM_KEY_TRANSFORMS)
 
     @classmethod
     def from_hf_config(

--- a/curated_transformers/models/bert/_hf.py
+++ b/curated_transformers/models/bert/_hf.py
@@ -1,23 +1,51 @@
-import re
-from types import MappingProxyType
-from typing import Any, Callable, Dict, Mapping, Tuple, Union
-
-from torch import Tensor
+from typing import Any, Callable, Dict, List, Tuple, Union
 
 from ...layers.activations import Activation
-from ..hf_hub import _process_hf_keys
+from ...util.string import StringTransform, StrLStrip, StrRepl, StrSub, StrSubInv
+from ..hf_hub.conversion import process_hf_keys
 from .config import BERTConfig
 
-HF_KEY_TO_CURATED_KEY = MappingProxyType(
-    {
-        "embeddings.word_embeddings.weight": "embeddings.piece_embeddings.weight",
-        "embeddings.token_type_embeddings.weight": "embeddings.type_embeddings.weight",
-        "embeddings.position_embeddings.weight": "embeddings.position_embeddings.weight",
-        "embeddings.LayerNorm.weight": "embeddings.embed_output_layer_norm.weight",
-        "embeddings.LayerNorm.bias": "embeddings.embed_output_layer_norm.bias",
-    }
-)
-
+# Order-dependent.
+HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
+    # Old HF parameter names (one-way transforms).
+    StrSub((r"\.gamma$", ".weight"), backward=None),
+    StrSub((r"\.beta$", ".bias"), backward=None),
+    # Prefixes.
+    StrLStrip("bert.", reversible=False),
+    StrSub(
+        (r"^encoder\.(layer\.)", "\\1"),
+        (r"^(layer\.)", "encoder.\\1"),
+    ),
+    # Layers.
+    StrSub((r"^layer", "layers"), (r"^layers", "layer")),
+    # Attention blocks.
+    StrSub(
+        (r"\.attention\.self\.(query|key|value)", ".mha.\\1"),
+        (r"\.mha\.(query|key|value)", ".attention.self.\\1"),
+    ),
+    StrSubInv((r".attention.output.dense", ".mha.output")),
+    StrSubInv((r".attention.output.LayerNorm", ".attn_residual_layer_norm")),
+    # Pointwise feed-forward layers.
+    StrSubInv((r".intermediate.dense", ".ffn.intermediate")),
+    StrSub(
+        (r"(\.\d+)\.output\.LayerNorm", "\\1.ffn_residual_layer_norm"),
+        (r"(\.\d+)\.ffn_residual_layer_norm", "\\1.output.LayerNorm"),
+    ),
+    StrSub(
+        (r"(\.\d+)\.output\.dense", "\\1.ffn.output"),
+        (r"(\.\d+)\.ffn\.output", "\\1.output.dense"),
+    ),
+    # Embeddings.
+    StrRepl("embeddings.word_embeddings.weight", "embeddings.piece_embeddings.weight"),
+    StrRepl(
+        "embeddings.token_type_embeddings.weight", "embeddings.type_embeddings.weight"
+    ),
+    StrRepl(
+        "embeddings.position_embeddings.weight", "embeddings.position_embeddings.weight"
+    ),
+    StrRepl("embeddings.LayerNorm.weight", "embeddings.embed_output_layer_norm.weight"),
+    StrRepl("embeddings.LayerNorm.bias", "embeddings.embed_output_layer_norm.bias"),
+]
 
 HF_CONFIG_KEY_MAPPING: Dict[str, Union[str, Tuple[str, Callable]]] = {
     "attention_probs_dropout_prob": "attention_probs_dropout_prob",
@@ -35,61 +63,10 @@ HF_CONFIG_KEY_MAPPING: Dict[str, Union[str, Tuple[str, Callable]]] = {
 
 
 def convert_hf_config(hf_config: Any) -> BERTConfig:
-    kwargs = _process_hf_keys("BERT", hf_config, HF_CONFIG_KEY_MAPPING)
+    kwargs = process_hf_keys("BERT", hf_config, HF_CONFIG_KEY_MAPPING)
 
     return BERTConfig(
         embedding_width=hf_config["hidden_size"],
         model_max_length=hf_config["max_position_embeddings"],
         **kwargs,
     )
-
-
-def convert_hf_state_dict(params: Mapping[str, Tensor]) -> Mapping[str, Tensor]:
-    out = {}
-
-    renamed_params = _rename_old_hf_names(params)
-
-    # Strip the `bert` prefix from BERT model parameters.
-    stripped_params = {re.sub(r"^bert\.", "", k): v for k, v in renamed_params.items()}
-
-    for name, parameter in stripped_params.items():
-        if "encoder.layer." not in name:
-            continue
-
-        # TODO: Make these substitutions less ugly.
-
-        # Remove the prefix and rename the internal 'layers' variable.
-        name = re.sub(r"^encoder\.", "", name)
-        name = re.sub(r"^layer", "layers", name)
-
-        # The HF model has one more level of indirection for the output layers in their
-        # attention heads and the feed-forward network layers.
-        name = re.sub(r"\.attention\.self\.(query|key|value)", r".mha.\1", name)
-        name = re.sub(r"\.attention\.(output)\.dense", r".mha.\1", name)
-        name = re.sub(
-            r"\.attention\.output\.LayerNorm", r".attn_residual_layer_norm", name
-        )
-        name = re.sub(r"\.(intermediate)\.dense", r".ffn.\1", name)
-        name = re.sub(
-            r"(\.\d+)\.output\.LayerNorm", r"\1.ffn_residual_layer_norm", name
-        )
-        name = re.sub(r"(\.\d+)\.(output)\.dense", r"\1.ffn.\2", name)
-
-        out[name] = parameter
-
-    for hf_name, curated_name in HF_KEY_TO_CURATED_KEY.items():
-        if hf_name in stripped_params:
-            out[curated_name] = stripped_params[hf_name]
-
-    return out
-
-
-def _rename_old_hf_names(
-    params: Mapping[str, Tensor],
-) -> Mapping[str, Tensor]:
-    out = {}
-    for name, parameter in params.items():
-        name = re.sub(r"\.gamma$", ".weight", name)
-        name = re.sub(r"\.beta$", ".bias", name)
-        out[name] = parameter
-    return out

--- a/curated_transformers/models/bert/_hf.py
+++ b/curated_transformers/models/bert/_hf.py
@@ -1,60 +1,60 @@
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 from ...layers.activations import Activation
-from ...util.string import (
-    StringRemovePrefix,
-    StringReplace,
-    StringSubInvertible,
-    StringSubRegEx,
-    StringTransform,
-)
+from ...util.string import StringTransform, StringTransformations
 from ..hf_hub.conversion import process_hf_keys
 from .config import BERTConfig
 
 # Order-dependent.
 HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
     # Old HF parameter names (one-way transforms).
-    StringSubRegEx((r"\.gamma$", ".weight"), backward=None),
-    StringSubRegEx((r"\.beta$", ".bias"), backward=None),
+    StringTransformations.regex_sub((r"\.gamma$", ".weight"), backward=None),
+    StringTransformations.regex_sub((r"\.beta$", ".bias"), backward=None),
     # Prefixes.
-    StringRemovePrefix("bert.", reversible=False),
-    StringSubRegEx(
+    StringTransformations.remove_prefix("bert.", reversible=False),
+    StringTransformations.regex_sub(
         (r"^encoder\.(layer\.)", "\\1"),
         (r"^(layer\.)", "encoder.\\1"),
     ),
     # Layers.
-    StringSubRegEx((r"^layer", "layers"), (r"^layers", "layer")),
+    StringTransformations.regex_sub((r"^layer", "layers"), (r"^layers", "layer")),
     # Attention blocks.
-    StringSubRegEx(
+    StringTransformations.regex_sub(
         (r"\.attention\.self\.(query|key|value)", ".mha.\\1"),
         (r"\.mha\.(query|key|value)", ".attention.self.\\1"),
     ),
-    StringSubInvertible((r".attention.output.dense", ".mha.output")),
-    StringSubInvertible((r".attention.output.LayerNorm", ".attn_residual_layer_norm")),
+    StringTransformations.regex_sub_invertible(
+        (r".attention.output.dense", ".mha.output")
+    ),
+    StringTransformations.regex_sub_invertible(
+        (r".attention.output.LayerNorm", ".attn_residual_layer_norm")
+    ),
     # Pointwise feed-forward layers.
-    StringSubInvertible((r".intermediate.dense", ".ffn.intermediate")),
-    StringSubRegEx(
+    StringTransformations.regex_sub_invertible(
+        (r".intermediate.dense", ".ffn.intermediate")
+    ),
+    StringTransformations.regex_sub(
         (r"(\.\d+)\.output\.LayerNorm", "\\1.ffn_residual_layer_norm"),
         (r"(\.\d+)\.ffn_residual_layer_norm", "\\1.output.LayerNorm"),
     ),
-    StringSubRegEx(
+    StringTransformations.regex_sub(
         (r"(\.\d+)\.output\.dense", "\\1.ffn.output"),
         (r"(\.\d+)\.ffn\.output", "\\1.output.dense"),
     ),
     # Embeddings.
-    StringReplace(
+    StringTransformations.replace(
         "embeddings.word_embeddings.weight", "embeddings.piece_embeddings.weight"
     ),
-    StringReplace(
+    StringTransformations.replace(
         "embeddings.token_type_embeddings.weight", "embeddings.type_embeddings.weight"
     ),
-    StringReplace(
+    StringTransformations.replace(
         "embeddings.position_embeddings.weight", "embeddings.position_embeddings.weight"
     ),
-    StringReplace(
+    StringTransformations.replace(
         "embeddings.LayerNorm.weight", "embeddings.embed_output_layer_norm.weight"
     ),
-    StringReplace(
+    StringTransformations.replace(
         "embeddings.LayerNorm.bias", "embeddings.embed_output_layer_norm.bias"
     ),
 ]

--- a/curated_transformers/models/bert/_hf.py
+++ b/curated_transformers/models/bert/_hf.py
@@ -1,50 +1,62 @@
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 from ...layers.activations import Activation
-from ...util.string import StringTransform, StrLStrip, StrRepl, StrSub, StrSubInv
+from ...util.string import (
+    StringRemovePrefix,
+    StringReplace,
+    StringSubInvertible,
+    StringSubRegEx,
+    StringTransform,
+)
 from ..hf_hub.conversion import process_hf_keys
 from .config import BERTConfig
 
 # Order-dependent.
 HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
     # Old HF parameter names (one-way transforms).
-    StrSub((r"\.gamma$", ".weight"), backward=None),
-    StrSub((r"\.beta$", ".bias"), backward=None),
+    StringSubRegEx((r"\.gamma$", ".weight"), backward=None),
+    StringSubRegEx((r"\.beta$", ".bias"), backward=None),
     # Prefixes.
-    StrLStrip("bert.", reversible=False),
-    StrSub(
+    StringRemovePrefix("bert.", reversible=False),
+    StringSubRegEx(
         (r"^encoder\.(layer\.)", "\\1"),
         (r"^(layer\.)", "encoder.\\1"),
     ),
     # Layers.
-    StrSub((r"^layer", "layers"), (r"^layers", "layer")),
+    StringSubRegEx((r"^layer", "layers"), (r"^layers", "layer")),
     # Attention blocks.
-    StrSub(
+    StringSubRegEx(
         (r"\.attention\.self\.(query|key|value)", ".mha.\\1"),
         (r"\.mha\.(query|key|value)", ".attention.self.\\1"),
     ),
-    StrSubInv((r".attention.output.dense", ".mha.output")),
-    StrSubInv((r".attention.output.LayerNorm", ".attn_residual_layer_norm")),
+    StringSubInvertible((r".attention.output.dense", ".mha.output")),
+    StringSubInvertible((r".attention.output.LayerNorm", ".attn_residual_layer_norm")),
     # Pointwise feed-forward layers.
-    StrSubInv((r".intermediate.dense", ".ffn.intermediate")),
-    StrSub(
+    StringSubInvertible((r".intermediate.dense", ".ffn.intermediate")),
+    StringSubRegEx(
         (r"(\.\d+)\.output\.LayerNorm", "\\1.ffn_residual_layer_norm"),
         (r"(\.\d+)\.ffn_residual_layer_norm", "\\1.output.LayerNorm"),
     ),
-    StrSub(
+    StringSubRegEx(
         (r"(\.\d+)\.output\.dense", "\\1.ffn.output"),
         (r"(\.\d+)\.ffn\.output", "\\1.output.dense"),
     ),
     # Embeddings.
-    StrRepl("embeddings.word_embeddings.weight", "embeddings.piece_embeddings.weight"),
-    StrRepl(
+    StringReplace(
+        "embeddings.word_embeddings.weight", "embeddings.piece_embeddings.weight"
+    ),
+    StringReplace(
         "embeddings.token_type_embeddings.weight", "embeddings.type_embeddings.weight"
     ),
-    StrRepl(
+    StringReplace(
         "embeddings.position_embeddings.weight", "embeddings.position_embeddings.weight"
     ),
-    StrRepl("embeddings.LayerNorm.weight", "embeddings.embed_output_layer_norm.weight"),
-    StrRepl("embeddings.LayerNorm.bias", "embeddings.embed_output_layer_norm.bias"),
+    StringReplace(
+        "embeddings.LayerNorm.weight", "embeddings.embed_output_layer_norm.weight"
+    ),
+    StringReplace(
+        "embeddings.LayerNorm.bias", "embeddings.embed_output_layer_norm.bias"
+    ),
 ]
 
 HF_CONFIG_KEY_MAPPING: Dict[str, Union[str, Tuple[str, Callable]]] = {

--- a/curated_transformers/models/bert/_hf.py
+++ b/curated_transformers/models/bert/_hf.py
@@ -23,16 +23,12 @@ HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
         (r"\.attention\.self\.(query|key|value)", ".mha.\\1"),
         (r"\.mha\.(query|key|value)", ".attention.self.\\1"),
     ),
-    StringTransformations.regex_sub_invertible(
-        (r".attention.output.dense", ".mha.output")
-    ),
-    StringTransformations.regex_sub_invertible(
-        (r".attention.output.LayerNorm", ".attn_residual_layer_norm")
+    StringTransformations.sub(".attention.output.dense", ".mha.output"),
+    StringTransformations.sub(
+        r".attention.output.LayerNorm", ".attn_residual_layer_norm"
     ),
     # Pointwise feed-forward layers.
-    StringTransformations.regex_sub_invertible(
-        (r".intermediate.dense", ".ffn.intermediate")
-    ),
+    StringTransformations.sub(".intermediate.dense", ".ffn.intermediate"),
     StringTransformations.regex_sub(
         (r"(\.\d+)\.output\.LayerNorm", "\\1.ffn_residual_layer_norm"),
         (r"(\.\d+)\.ffn_residual_layer_norm", "\\1.output.LayerNorm"),

--- a/curated_transformers/models/bert/encoder.py
+++ b/curated_transformers/models/bert/encoder.py
@@ -16,8 +16,9 @@ from ...layers.transformer import (
     TransformerLayerNorms,
 )
 from ..hf_hub import FromHFHub
+from ..hf_hub.conversion import state_dict_from_hf, state_dict_to_hf
 from ..transformer import TransformerEncoder
-from ._hf import convert_hf_config, convert_hf_state_dict
+from ._hf import HF_PARAM_KEY_TRANSFORMS, convert_hf_config
 from .config import BERTConfig
 
 # Only provided as typing.Self in Python 3.11+.
@@ -105,8 +106,16 @@ class BERTEncoder(TransformerEncoder[BERTConfig], FromHFHub):
         )
 
     @classmethod
-    def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):
-        return convert_hf_state_dict(params)
+    def state_dict_from_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_from_hf(params, HF_PARAM_KEY_TRANSFORMS)
+
+    @classmethod
+    def state_dict_to_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_to_hf(params, HF_PARAM_KEY_TRANSFORMS)
 
     @classmethod
     def from_hf_config(

--- a/curated_transformers/models/falcon/_hf.py
+++ b/curated_transformers/models/falcon/_hf.py
@@ -1,11 +1,6 @@
 from typing import Any, Callable, Dict, List, Tuple, Union
 
-from ...util.string import (
-    StringRemovePrefix,
-    StringSubInvertible,
-    StringSubRegEx,
-    StringTransform,
-)
+from ...util.string import StringTransform, StringTransformations
 from ..hf_hub.conversion import process_hf_keys
 from .config import FalconConfig
 
@@ -16,32 +11,38 @@ EXTRA_KWARG_KEYS = [ATTENTION_DROPOUT, HIDDEN_DROPOUT]
 
 # Order-dependent.
 COMMON_HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
-    StringSubRegEx((r"^h\.", "layers."), (r"^layers\.", "h.")),
-    StringSubInvertible((r"decoder.h.", "decoder.layers.")),
+    StringTransformations.regex_sub((r"^h\.", "layers."), (r"^layers\.", "h.")),
+    StringTransformations.regex_sub_invertible((r"decoder.h.", "decoder.layers.")),
     # Attention blocks.
-    StringSubInvertible((r".self_attention", ".mha")),
-    StringSubInvertible((r".mha.query_key_value", ".mha.input")),
-    StringSubInvertible((r".mha.dense", ".mha.output")),
+    StringTransformations.regex_sub_invertible((r".self_attention", ".mha")),
+    StringTransformations.regex_sub_invertible((r".mha.query_key_value", ".mha.input")),
+    StringTransformations.regex_sub_invertible((r".mha.dense", ".mha.output")),
     # Pointwise feedforward.
-    StringSubInvertible((r".mlp", ".ffn")),
-    StringSubInvertible((r".dense_h_to_4h", ".intermediate")),
-    StringSubInvertible((r".ffn.dense_4h_to_h", ".ffn.output")),
+    StringTransformations.regex_sub_invertible((r".mlp", ".ffn")),
+    StringTransformations.regex_sub_invertible((r".dense_h_to_4h", ".intermediate")),
+    StringTransformations.regex_sub_invertible((r".ffn.dense_4h_to_h", ".ffn.output")),
     # Layer norms.
-    StringSubInvertible((r".input_layernorm", ".attn_layer_norm")),
-    StringSubInvertible((r".ln_attn", ".attn_input_layer_norm")),
-    StringSubInvertible((r".post_attention_layernorm", ".ffn_layer_norm")),
-    StringSubInvertible((r".ln_mlp", ".ffn_input_layer_norm")),
-    StringSubInvertible((r"ln_f.", "output_layer_norm.")),
+    StringTransformations.regex_sub_invertible(
+        (r".input_layernorm", ".attn_layer_norm")
+    ),
+    StringTransformations.regex_sub_invertible((r".ln_attn", ".attn_input_layer_norm")),
+    StringTransformations.regex_sub_invertible(
+        (r".post_attention_layernorm", ".ffn_layer_norm")
+    ),
+    StringTransformations.regex_sub_invertible((r".ln_mlp", ".ffn_input_layer_norm")),
+    StringTransformations.regex_sub_invertible((r"ln_f.", "output_layer_norm.")),
     # Embeddings.
-    StringSubInvertible((r"word_embeddings.", "embeddings.piece_embeddings.")),
-    StringSubInvertible((r"lm_head.", "output_embeddings.")),
+    StringTransformations.regex_sub_invertible(
+        (r"word_embeddings.", "embeddings.piece_embeddings.")
+    ),
+    StringTransformations.regex_sub_invertible((r"lm_head.", "output_embeddings.")),
 ]
 
 DECODER_HF_PARAM_KEY_TRANSFORMS = [
-    StringRemovePrefix("transformer.", reversible=False)
+    StringTransformations.remove_prefix("transformer.", reversible=False)
 ] + COMMON_HF_PARAM_KEY_TRANSFORMS
 CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS = [
-    StringSubInvertible((r"transformer.", "decoder.")),
+    StringTransformations.regex_sub_invertible((r"transformer.", "decoder.")),
 ] + COMMON_HF_PARAM_KEY_TRANSFORMS
 
 HF_CONFIG_KEY_MAPPING_REFINED_WEB_MODEL: Dict[str, Union[str, Tuple[str, Callable]]] = {

--- a/curated_transformers/models/falcon/_hf.py
+++ b/curated_transformers/models/falcon/_hf.py
@@ -12,37 +12,31 @@ EXTRA_KWARG_KEYS = [ATTENTION_DROPOUT, HIDDEN_DROPOUT]
 # Order-dependent.
 COMMON_HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
     StringTransformations.regex_sub((r"^h\.", "layers."), (r"^layers\.", "h.")),
-    StringTransformations.regex_sub_invertible((r"decoder.h.", "decoder.layers.")),
+    StringTransformations.sub("decoder.h.", "decoder.layers."),
     # Attention blocks.
-    StringTransformations.regex_sub_invertible((r".self_attention", ".mha")),
-    StringTransformations.regex_sub_invertible((r".mha.query_key_value", ".mha.input")),
-    StringTransformations.regex_sub_invertible((r".mha.dense", ".mha.output")),
+    StringTransformations.sub(".self_attention", ".mha"),
+    StringTransformations.sub(".mha.query_key_value", ".mha.input"),
+    StringTransformations.sub(".mha.dense", ".mha.output"),
     # Pointwise feedforward.
-    StringTransformations.regex_sub_invertible((r".mlp", ".ffn")),
-    StringTransformations.regex_sub_invertible((r".dense_h_to_4h", ".intermediate")),
-    StringTransformations.regex_sub_invertible((r".ffn.dense_4h_to_h", ".ffn.output")),
+    StringTransformations.sub(".mlp", ".ffn"),
+    StringTransformations.sub(".dense_h_to_4h", ".intermediate"),
+    StringTransformations.sub(".ffn.dense_4h_to_h", ".ffn.output"),
     # Layer norms.
-    StringTransformations.regex_sub_invertible(
-        (r".input_layernorm", ".attn_layer_norm")
-    ),
-    StringTransformations.regex_sub_invertible((r".ln_attn", ".attn_input_layer_norm")),
-    StringTransformations.regex_sub_invertible(
-        (r".post_attention_layernorm", ".ffn_layer_norm")
-    ),
-    StringTransformations.regex_sub_invertible((r".ln_mlp", ".ffn_input_layer_norm")),
-    StringTransformations.regex_sub_invertible((r"ln_f.", "output_layer_norm.")),
+    StringTransformations.sub(".input_layernorm", ".attn_layer_norm"),
+    StringTransformations.sub(".ln_attn", ".attn_input_layer_norm"),
+    StringTransformations.sub(".post_attention_layernorm", ".ffn_layer_norm"),
+    StringTransformations.sub(".ln_mlp", ".ffn_input_layer_norm"),
+    StringTransformations.sub("ln_f.", "output_layer_norm."),
     # Embeddings.
-    StringTransformations.regex_sub_invertible(
-        (r"word_embeddings.", "embeddings.piece_embeddings.")
-    ),
-    StringTransformations.regex_sub_invertible((r"lm_head.", "output_embeddings.")),
+    StringTransformations.sub("word_embeddings.", "embeddings.piece_embeddings."),
+    StringTransformations.sub("lm_head.", "output_embeddings."),
 ]
 
 DECODER_HF_PARAM_KEY_TRANSFORMS = [
     StringTransformations.remove_prefix("transformer.", reversible=False)
 ] + COMMON_HF_PARAM_KEY_TRANSFORMS
 CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS = [
-    StringTransformations.regex_sub_invertible((r"transformer.", "decoder.")),
+    StringTransformations.sub("transformer.", "decoder."),
 ] + COMMON_HF_PARAM_KEY_TRANSFORMS
 
 HF_CONFIG_KEY_MAPPING_REFINED_WEB_MODEL: Dict[str, Union[str, Tuple[str, Callable]]] = {

--- a/curated_transformers/models/falcon/_hf.py
+++ b/curated_transformers/models/falcon/_hf.py
@@ -1,15 +1,43 @@
-import re
-from typing import Any, Callable, Dict, Mapping, Tuple, Union
+from typing import Any, Callable, Dict, List, Tuple, Union
 
-from torch import Tensor
-
-from ..hf_hub import _process_hf_keys
-from ..module import DecoderModule
+from ...util.string import StringTransform, StrLStrip, StrSub, StrSubInv
+from ..hf_hub.conversion import process_hf_keys
 from .config import FalconConfig
 
 ATTENTION_DROPOUT = "attention_probs_dropout_prob"
 HIDDEN_DROPOUT = "hidden_dropout_prob"
 EXTRA_KWARG_KEYS = [ATTENTION_DROPOUT, HIDDEN_DROPOUT]
+
+
+# Order-dependent.
+COMMON_HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
+    StrSub((r"^h\.", "layers."), (r"^layers\.", "h.")),
+    StrSubInv((r"decoder.h.", "decoder.layers.")),
+    # Attention blocks.
+    StrSubInv((r".self_attention", ".mha")),
+    StrSubInv((r".mha.query_key_value", ".mha.input")),
+    StrSubInv((r".mha.dense", ".mha.output")),
+    # Pointwise feedforward.
+    StrSubInv((r".mlp", ".ffn")),
+    StrSubInv((r".dense_h_to_4h", ".intermediate")),
+    StrSubInv((r".ffn.dense_4h_to_h", ".ffn.output")),
+    # Layer norms.
+    StrSubInv((r".input_layernorm", ".attn_layer_norm")),
+    StrSubInv((r".ln_attn", ".attn_input_layer_norm")),
+    StrSubInv((r".post_attention_layernorm", ".ffn_layer_norm")),
+    StrSubInv((r".ln_mlp", ".ffn_input_layer_norm")),
+    StrSubInv((r"ln_f.", "output_layer_norm.")),
+    # Embeddings.
+    StrSubInv((r"word_embeddings.", "embeddings.piece_embeddings.")),
+    StrSubInv((r"lm_head.", "output_embeddings.")),
+]
+
+DECODER_HF_PARAM_KEY_TRANSFORMS = [
+    StrLStrip("transformer.", reversible=False)
+] + COMMON_HF_PARAM_KEY_TRANSFORMS
+CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS = [
+    StrSubInv((r"transformer.", "decoder.")),
+] + COMMON_HF_PARAM_KEY_TRANSFORMS
 
 HF_CONFIG_KEY_MAPPING_REFINED_WEB_MODEL: Dict[str, Union[str, Tuple[str, Callable]]] = {
     "hidden_size": "hidden_width",
@@ -45,7 +73,7 @@ def convert_hf_config(hf_config: Any) -> FalconConfig:
 
 
 def _convert_hf_config_refined_web_model(hf_config: Any) -> FalconConfig:
-    kwargs = _process_hf_keys(
+    kwargs = process_hf_keys(
         "Falcon", hf_config, HF_CONFIG_KEY_MAPPING_REFINED_WEB_MODEL, EXTRA_KWARG_KEYS
     )
 
@@ -79,7 +107,7 @@ def _convert_hf_config_refined_web_model(hf_config: Any) -> FalconConfig:
 
 
 def _convert_hf_config_falcon(hf_config: Any) -> FalconConfig:
-    kwargs = _process_hf_keys(
+    kwargs = process_hf_keys(
         "Falcon", hf_config, HF_CONFIG_KEY_MAPPING_FALCON, EXTRA_KWARG_KEYS
     )
 
@@ -104,53 +132,3 @@ def _convert_hf_config_falcon(hf_config: Any) -> FalconConfig:
         rotary_embedding_fraction=1.0,
         **kwargs,
     )
-
-
-def convert_hf_state_dict(cls, params: Mapping[str, Tensor]) -> Mapping[str, Tensor]:
-    """
-    Convert state dict from HF paramater naming to ours.
-    The function is insensitive to prefixes, to allow loading
-    both the decoder and the full LM.
-    """
-    if issubclass(cls, DecoderModule):
-        stripped_params = {
-            re.sub(r"^transformer\.", "", k): v for k, v in params.items()
-        }
-    else:
-        stripped_params = {
-            re.sub(r"^transformer\.", "decoder.", k): v for k, v in params.items()
-        }
-
-    out = {}
-    for name, parameter in stripped_params.items():
-        # These parameters are all created on-the-fly.
-        if "rotary_emb" in name or "attention.bias" in name or "masked_bias" in name:
-            continue
-
-        name = re.sub(r"^h\.", "layers.", name)
-        name = re.sub(r"decoder\.h\.", "decoder.layers.", name)
-
-        # Attention
-        name = re.sub(r"\.self_attention", r".mha", name)
-        name = re.sub(r"\.query_key_value", r".input", name)
-        name = re.sub(r"\.mha\.dense", r".mha.output", name)
-
-        # Pointwise feedforward
-        name = re.sub(r"\.mlp", r".ffn", name)
-        name = re.sub(r"\.dense_h_to_4h", r".intermediate", name)
-        name = re.sub(r"\.dense_4h_to_h", r".output", name)
-
-        # Layer norms
-        name = re.sub(r"\.input_layernorm", r".attn_layer_norm", name)
-        name = re.sub(r"\.ln_attn", r".attn_input_layer_norm", name)
-        name = re.sub(r"\.post_attention_layernorm", r".ffn_layer_norm", name)
-        name = re.sub(r"\.ln_mlp", r".ffn_input_layer_norm", name)
-        name = re.sub(r"ln_f\.", r"output_layer_norm.", name)
-
-        # Embeddings
-        name = re.sub(r"word_embeddings\.", r"embeddings.piece_embeddings.", name)
-        name = re.sub(r"lm_head\.", r"output_embeddings.", name)
-
-        out[name] = parameter
-
-    return out

--- a/curated_transformers/models/falcon/_hf.py
+++ b/curated_transformers/models/falcon/_hf.py
@@ -1,6 +1,11 @@
 from typing import Any, Callable, Dict, List, Tuple, Union
 
-from ...util.string import StringTransform, StrLStrip, StrSub, StrSubInv
+from ...util.string import (
+    StringRemovePrefix,
+    StringSubInvertible,
+    StringSubRegEx,
+    StringTransform,
+)
 from ..hf_hub.conversion import process_hf_keys
 from .config import FalconConfig
 
@@ -11,32 +16,32 @@ EXTRA_KWARG_KEYS = [ATTENTION_DROPOUT, HIDDEN_DROPOUT]
 
 # Order-dependent.
 COMMON_HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
-    StrSub((r"^h\.", "layers."), (r"^layers\.", "h.")),
-    StrSubInv((r"decoder.h.", "decoder.layers.")),
+    StringSubRegEx((r"^h\.", "layers."), (r"^layers\.", "h.")),
+    StringSubInvertible((r"decoder.h.", "decoder.layers.")),
     # Attention blocks.
-    StrSubInv((r".self_attention", ".mha")),
-    StrSubInv((r".mha.query_key_value", ".mha.input")),
-    StrSubInv((r".mha.dense", ".mha.output")),
+    StringSubInvertible((r".self_attention", ".mha")),
+    StringSubInvertible((r".mha.query_key_value", ".mha.input")),
+    StringSubInvertible((r".mha.dense", ".mha.output")),
     # Pointwise feedforward.
-    StrSubInv((r".mlp", ".ffn")),
-    StrSubInv((r".dense_h_to_4h", ".intermediate")),
-    StrSubInv((r".ffn.dense_4h_to_h", ".ffn.output")),
+    StringSubInvertible((r".mlp", ".ffn")),
+    StringSubInvertible((r".dense_h_to_4h", ".intermediate")),
+    StringSubInvertible((r".ffn.dense_4h_to_h", ".ffn.output")),
     # Layer norms.
-    StrSubInv((r".input_layernorm", ".attn_layer_norm")),
-    StrSubInv((r".ln_attn", ".attn_input_layer_norm")),
-    StrSubInv((r".post_attention_layernorm", ".ffn_layer_norm")),
-    StrSubInv((r".ln_mlp", ".ffn_input_layer_norm")),
-    StrSubInv((r"ln_f.", "output_layer_norm.")),
+    StringSubInvertible((r".input_layernorm", ".attn_layer_norm")),
+    StringSubInvertible((r".ln_attn", ".attn_input_layer_norm")),
+    StringSubInvertible((r".post_attention_layernorm", ".ffn_layer_norm")),
+    StringSubInvertible((r".ln_mlp", ".ffn_input_layer_norm")),
+    StringSubInvertible((r"ln_f.", "output_layer_norm.")),
     # Embeddings.
-    StrSubInv((r"word_embeddings.", "embeddings.piece_embeddings.")),
-    StrSubInv((r"lm_head.", "output_embeddings.")),
+    StringSubInvertible((r"word_embeddings.", "embeddings.piece_embeddings.")),
+    StringSubInvertible((r"lm_head.", "output_embeddings.")),
 ]
 
 DECODER_HF_PARAM_KEY_TRANSFORMS = [
-    StrLStrip("transformer.", reversible=False)
+    StringRemovePrefix("transformer.", reversible=False)
 ] + COMMON_HF_PARAM_KEY_TRANSFORMS
 CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS = [
-    StrSubInv((r"transformer.", "decoder.")),
+    StringSubInvertible((r"transformer.", "decoder.")),
 ] + COMMON_HF_PARAM_KEY_TRANSFORMS
 
 HF_CONFIG_KEY_MAPPING_REFINED_WEB_MODEL: Dict[str, Union[str, Tuple[str, Callable]]] = {

--- a/curated_transformers/models/falcon/causal_lm.py
+++ b/curated_transformers/models/falcon/causal_lm.py
@@ -6,8 +6,9 @@ from torch.nn import Linear
 
 from ...quantization.quantizable import Quantizable
 from ..hf_hub import FromHFHub
+from ..hf_hub.conversion import state_dict_from_hf, state_dict_to_hf
 from ..transformer import TransformerCausalLM
-from ._hf import convert_hf_config, convert_hf_state_dict
+from ._hf import CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS, convert_hf_config
 from .config import FalconConfig
 from .decoder import FalconDecoder
 
@@ -46,8 +47,16 @@ class FalconCausalLM(TransformerCausalLM[FalconConfig], FromHFHub, Quantizable):
         )
 
     @classmethod
-    def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):
-        return convert_hf_state_dict(cls, params)
+    def state_dict_from_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_from_hf(params, CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS)
+
+    @classmethod
+    def state_dict_to_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_to_hf(params, CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS)
 
     @classmethod
     def from_hf_config(

--- a/curated_transformers/models/falcon/decoder.py
+++ b/curated_transformers/models/falcon/decoder.py
@@ -22,8 +22,9 @@ from ...layers.transformer import (
     TransformerLayerNorms,
 )
 from ..hf_hub import FromHFHub
+from ..hf_hub.conversion import state_dict_from_hf, state_dict_to_hf
 from ..transformer import TransformerDecoder
-from ._hf import convert_hf_config, convert_hf_state_dict
+from ._hf import DECODER_HF_PARAM_KEY_TRANSFORMS, convert_hf_config
 from .config import FalconConfig
 from .layer import OldFalconDecoderLayer
 
@@ -86,8 +87,16 @@ class FalconDecoder(TransformerDecoder[FalconConfig], FromHFHub):
         )
 
     @classmethod
-    def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):
-        return convert_hf_state_dict(cls, params)
+    def state_dict_from_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_from_hf(params, DECODER_HF_PARAM_KEY_TRANSFORMS)
+
+    @classmethod
+    def state_dict_to_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_to_hf(params, DECODER_HF_PARAM_KEY_TRANSFORMS)
 
     @classmethod
     def from_hf_config(

--- a/curated_transformers/models/gpt_neox/_hf.py
+++ b/curated_transformers/models/gpt_neox/_hf.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 from ...layers.activations import Activation
-from ...util.string import StringTransform, StrLStrip, StrSubInv
+from ...util.string import StringRemovePrefix, StringSubInvertible, StringTransform
 from ..hf_hub.conversion import process_hf_keys
 from .config import GPTNeoXConfig
 
@@ -11,26 +11,26 @@ EXTRA_KWARG_KEYS = [ATTENTION_DROPOUT, HIDDEN_DROPOUT]
 
 # Order-dependent.
 COMMON_HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
-    StrSubInv((r"gpt_neox", "decoder")),
+    StringSubInvertible((r"gpt_neox", "decoder")),
     # Attention blocks.
-    StrSubInv((r".attention", ".mha")),
-    StrSubInv((r".mha.query_key_value", ".mha.input")),
-    StrSubInv((r".mha.dense", ".mha.output")),
+    StringSubInvertible((r".attention", ".mha")),
+    StringSubInvertible((r".mha.query_key_value", ".mha.input")),
+    StringSubInvertible((r".mha.dense", ".mha.output")),
     # Pointwise feedforward.
-    StrSubInv((r".mlp", ".ffn")),
-    StrSubInv((r".dense_h_to_4h", ".intermediate")),
-    StrSubInv((r".ffn.dense_4h_to_h", ".ffn.output")),
+    StringSubInvertible((r".mlp", ".ffn")),
+    StringSubInvertible((r".dense_h_to_4h", ".intermediate")),
+    StringSubInvertible((r".ffn.dense_4h_to_h", ".ffn.output")),
     # Layer norms.
-    StrSubInv((r".input_layernorm", ".attn_input_layer_norm")),
-    StrSubInv((r".post_attention_layernorm", ".ffn_input_layer_norm")),
-    StrSubInv((r"final_layer_norm.", "output_layer_norm.")),
+    StringSubInvertible((r".input_layernorm", ".attn_input_layer_norm")),
+    StringSubInvertible((r".post_attention_layernorm", ".ffn_input_layer_norm")),
+    StringSubInvertible((r"final_layer_norm.", "output_layer_norm.")),
     # Embeddings.
-    StrSubInv((r"embed_in.", "embeddings.piece_embeddings.")),
-    StrSubInv((r"embed_out.", "output_embeddings.")),
+    StringSubInvertible((r"embed_in.", "embeddings.piece_embeddings.")),
+    StringSubInvertible((r"embed_out.", "output_embeddings.")),
 ]
 
 DECODER_HF_PARAM_KEY_TRANSFORMS = [
-    StrLStrip("gpt_neox.", reversible=False)
+    StringRemovePrefix("gpt_neox.", reversible=False)
 ] + COMMON_HF_PARAM_KEY_TRANSFORMS
 CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS = COMMON_HF_PARAM_KEY_TRANSFORMS
 

--- a/curated_transformers/models/gpt_neox/_hf.py
+++ b/curated_transformers/models/gpt_neox/_hf.py
@@ -11,30 +11,22 @@ EXTRA_KWARG_KEYS = [ATTENTION_DROPOUT, HIDDEN_DROPOUT]
 
 # Order-dependent.
 COMMON_HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
-    StringTransformations.regex_sub_invertible((r"gpt_neox", "decoder")),
+    StringTransformations.sub("gpt_neox", "decoder"),
     # Attention blocks.
-    StringTransformations.regex_sub_invertible((r".attention", ".mha")),
-    StringTransformations.regex_sub_invertible((r".mha.query_key_value", ".mha.input")),
-    StringTransformations.regex_sub_invertible((r".mha.dense", ".mha.output")),
+    StringTransformations.sub(".attention", ".mha"),
+    StringTransformations.sub(".mha.query_key_value", ".mha.input"),
+    StringTransformations.sub(".mha.dense", ".mha.output"),
     # Pointwise feedforward.
-    StringTransformations.regex_sub_invertible((r".mlp", ".ffn")),
-    StringTransformations.regex_sub_invertible((r".dense_h_to_4h", ".intermediate")),
-    StringTransformations.regex_sub_invertible((r".ffn.dense_4h_to_h", ".ffn.output")),
+    StringTransformations.sub(".mlp", ".ffn"),
+    StringTransformations.sub(".dense_h_to_4h", ".intermediate"),
+    StringTransformations.sub(".ffn.dense_4h_to_h", ".ffn.output"),
     # Layer norms.
-    StringTransformations.regex_sub_invertible(
-        (r".input_layernorm", ".attn_input_layer_norm")
-    ),
-    StringTransformations.regex_sub_invertible(
-        (r".post_attention_layernorm", ".ffn_input_layer_norm")
-    ),
-    StringTransformations.regex_sub_invertible(
-        (r"final_layer_norm.", "output_layer_norm.")
-    ),
+    StringTransformations.sub(".input_layernorm", ".attn_input_layer_norm"),
+    StringTransformations.sub(".post_attention_layernorm", ".ffn_input_layer_norm"),
+    StringTransformations.sub("final_layer_norm.", "output_layer_norm."),
     # Embeddings.
-    StringTransformations.regex_sub_invertible(
-        (r"embed_in.", "embeddings.piece_embeddings.")
-    ),
-    StringTransformations.regex_sub_invertible((r"embed_out.", "output_embeddings.")),
+    StringTransformations.sub("embed_in.", "embeddings.piece_embeddings."),
+    StringTransformations.sub("embed_out.", "output_embeddings."),
 ]
 
 DECODER_HF_PARAM_KEY_TRANSFORMS = [

--- a/curated_transformers/models/gpt_neox/_hf.py
+++ b/curated_transformers/models/gpt_neox/_hf.py
@@ -1,16 +1,38 @@
-import re
-from typing import Any, Callable, Dict, Mapping, Tuple, Union
-
-from torch import Tensor
+from typing import Any, Callable, Dict, List, Tuple, Union
 
 from ...layers.activations import Activation
-from ..hf_hub import _process_hf_keys
-from ..module import DecoderModule
+from ...util.string import StringTransform, StrLStrip, StrSubInv
+from ..hf_hub.conversion import process_hf_keys
 from .config import GPTNeoXConfig
 
 ATTENTION_DROPOUT = "attention_probs_dropout_prob"
 HIDDEN_DROPOUT = "hidden_dropout_prob"
 EXTRA_KWARG_KEYS = [ATTENTION_DROPOUT, HIDDEN_DROPOUT]
+
+# Order-dependent.
+COMMON_HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
+    StrSubInv((r"gpt_neox", "decoder")),
+    # Attention blocks.
+    StrSubInv((r".attention", ".mha")),
+    StrSubInv((r".mha.query_key_value", ".mha.input")),
+    StrSubInv((r".mha.dense", ".mha.output")),
+    # Pointwise feedforward.
+    StrSubInv((r".mlp", ".ffn")),
+    StrSubInv((r".dense_h_to_4h", ".intermediate")),
+    StrSubInv((r".ffn.dense_4h_to_h", ".ffn.output")),
+    # Layer norms.
+    StrSubInv((r".input_layernorm", ".attn_input_layer_norm")),
+    StrSubInv((r".post_attention_layernorm", ".ffn_input_layer_norm")),
+    StrSubInv((r"final_layer_norm.", "output_layer_norm.")),
+    # Embeddings.
+    StrSubInv((r"embed_in.", "embeddings.piece_embeddings.")),
+    StrSubInv((r"embed_out.", "output_embeddings.")),
+]
+
+DECODER_HF_PARAM_KEY_TRANSFORMS = [
+    StrLStrip("gpt_neox.", reversible=False)
+] + COMMON_HF_PARAM_KEY_TRANSFORMS
+CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS = COMMON_HF_PARAM_KEY_TRANSFORMS
 
 HF_CONFIG_KEY_MAPPING: Dict[str, Union[str, Tuple[str, Callable]]] = {
     "hidden_act": ("activation", Activation),
@@ -27,57 +49,10 @@ HF_CONFIG_KEY_MAPPING: Dict[str, Union[str, Tuple[str, Callable]]] = {
 
 
 def convert_hf_config(hf_config: Any) -> GPTNeoXConfig:
-    kwargs = _process_hf_keys(
+    kwargs = process_hf_keys(
         "GPT-NeoX", hf_config, HF_CONFIG_KEY_MAPPING, EXTRA_KWARG_KEYS
     )
     return GPTNeoXConfig(
         model_max_length=hf_config["max_position_embeddings"],
         **kwargs,
     )
-
-
-def convert_hf_state_dict(cls, params: Mapping[str, Tensor]) -> Mapping[str, Tensor]:
-    """Convert state dict from HF paramater naming to ours.
-    The function is insensitive to prefixes, to allow loading
-    both the decoder and the full LM."""
-    if issubclass(cls, DecoderModule):
-        stripped_params = {
-            re.sub(r"^gpt_neox\.", "", k): v
-            for k, v in params.items()
-            # The decoder does not the output embeddings, avoid unexpected key.
-            if k != "embed_out.weight"
-        }
-    else:
-        # Rewrap as dict if necessay to make MyPy happy.
-        stripped_params = dict(params)
-
-    out = {}
-    for name, parameter in stripped_params.items():
-        # These parameters are all created on-the-fly.
-        if "rotary_emb" in name or "attention.bias" in name or "masked_bias" in name:
-            continue
-
-        name = name.replace("gpt_neox", "decoder")
-
-        # Attention
-        name = re.sub(r"\.attention", r".mha", name)
-        name = re.sub(r"\.query_key_value", r".input", name)
-        name = re.sub(r"\.mha\.dense", r".mha.output", name)
-
-        # Pointwise feedforward
-        name = re.sub(r"\.mlp", r".ffn", name)
-        name = re.sub(r"\.dense_h_to_4h", r".intermediate", name)
-        name = re.sub(r"\.dense_4h_to_h", r".output", name)
-
-        # Layer norms
-        name = re.sub(r"\.input_layernorm", r".attn_input_layer_norm", name)
-        name = re.sub(r"\.post_attention_layernorm", r".ffn_input_layer_norm", name)
-        name = re.sub(r"final_layer_norm\.", r"output_layer_norm.", name)
-
-        # Embeddings
-        name = re.sub(r"embed_in\.", r"embeddings.piece_embeddings.", name)
-        name = re.sub(r"embed_out\.", r"output_embeddings.", name)
-
-        out[name] = parameter
-
-    return out

--- a/curated_transformers/models/gpt_neox/_hf.py
+++ b/curated_transformers/models/gpt_neox/_hf.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 from ...layers.activations import Activation
-from ...util.string import StringRemovePrefix, StringSubInvertible, StringTransform
+from ...util.string import StringTransform, StringTransformations
 from ..hf_hub.conversion import process_hf_keys
 from .config import GPTNeoXConfig
 
@@ -11,26 +11,34 @@ EXTRA_KWARG_KEYS = [ATTENTION_DROPOUT, HIDDEN_DROPOUT]
 
 # Order-dependent.
 COMMON_HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
-    StringSubInvertible((r"gpt_neox", "decoder")),
+    StringTransformations.regex_sub_invertible((r"gpt_neox", "decoder")),
     # Attention blocks.
-    StringSubInvertible((r".attention", ".mha")),
-    StringSubInvertible((r".mha.query_key_value", ".mha.input")),
-    StringSubInvertible((r".mha.dense", ".mha.output")),
+    StringTransformations.regex_sub_invertible((r".attention", ".mha")),
+    StringTransformations.regex_sub_invertible((r".mha.query_key_value", ".mha.input")),
+    StringTransformations.regex_sub_invertible((r".mha.dense", ".mha.output")),
     # Pointwise feedforward.
-    StringSubInvertible((r".mlp", ".ffn")),
-    StringSubInvertible((r".dense_h_to_4h", ".intermediate")),
-    StringSubInvertible((r".ffn.dense_4h_to_h", ".ffn.output")),
+    StringTransformations.regex_sub_invertible((r".mlp", ".ffn")),
+    StringTransformations.regex_sub_invertible((r".dense_h_to_4h", ".intermediate")),
+    StringTransformations.regex_sub_invertible((r".ffn.dense_4h_to_h", ".ffn.output")),
     # Layer norms.
-    StringSubInvertible((r".input_layernorm", ".attn_input_layer_norm")),
-    StringSubInvertible((r".post_attention_layernorm", ".ffn_input_layer_norm")),
-    StringSubInvertible((r"final_layer_norm.", "output_layer_norm.")),
+    StringTransformations.regex_sub_invertible(
+        (r".input_layernorm", ".attn_input_layer_norm")
+    ),
+    StringTransformations.regex_sub_invertible(
+        (r".post_attention_layernorm", ".ffn_input_layer_norm")
+    ),
+    StringTransformations.regex_sub_invertible(
+        (r"final_layer_norm.", "output_layer_norm.")
+    ),
     # Embeddings.
-    StringSubInvertible((r"embed_in.", "embeddings.piece_embeddings.")),
-    StringSubInvertible((r"embed_out.", "output_embeddings.")),
+    StringTransformations.regex_sub_invertible(
+        (r"embed_in.", "embeddings.piece_embeddings.")
+    ),
+    StringTransformations.regex_sub_invertible((r"embed_out.", "output_embeddings.")),
 ]
 
 DECODER_HF_PARAM_KEY_TRANSFORMS = [
-    StringRemovePrefix("gpt_neox.", reversible=False)
+    StringTransformations.remove_prefix("gpt_neox.", reversible=False)
 ] + COMMON_HF_PARAM_KEY_TRANSFORMS
 CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS = COMMON_HF_PARAM_KEY_TRANSFORMS
 

--- a/curated_transformers/models/gpt_neox/causal_lm.py
+++ b/curated_transformers/models/gpt_neox/causal_lm.py
@@ -6,8 +6,9 @@ from torch.nn import Linear
 
 from ...quantization import Quantizable
 from ..hf_hub import FromHFHub
+from ..hf_hub.conversion import state_dict_from_hf, state_dict_to_hf
 from ..transformer import TransformerCausalLM
-from ._hf import convert_hf_config, convert_hf_state_dict
+from ._hf import CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS, convert_hf_config
 from .config import GPTNeoXConfig
 from .decoder import GPTNeoXDecoder
 
@@ -46,8 +47,16 @@ class GPTNeoXCausalLM(TransformerCausalLM[GPTNeoXConfig], FromHFHub, Quantizable
         )
 
     @classmethod
-    def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):
-        return convert_hf_state_dict(cls, params)
+    def state_dict_from_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_from_hf(params, CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS)
+
+    @classmethod
+    def state_dict_to_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_to_hf(params, CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS)
 
     @classmethod
     def from_hf_config(

--- a/curated_transformers/models/gpt_neox/decoder.py
+++ b/curated_transformers/models/gpt_neox/decoder.py
@@ -17,8 +17,9 @@ from ...layers.transformer import (
     TransformerLayerNorms,
 )
 from ..hf_hub import FromHFHub
+from ..hf_hub.conversion import state_dict_from_hf, state_dict_to_hf
 from ..transformer import TransformerDecoder
-from ._hf import convert_hf_config, convert_hf_state_dict
+from ._hf import DECODER_HF_PARAM_KEY_TRANSFORMS, convert_hf_config
 from .config import GPTNeoXConfig
 
 # Only provided as typing.Self in Python 3.11+.
@@ -114,8 +115,16 @@ class GPTNeoXDecoder(TransformerDecoder[GPTNeoXConfig], FromHFHub):
         )
 
     @classmethod
-    def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):
-        return convert_hf_state_dict(cls, params)
+    def state_dict_from_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_from_hf(params, DECODER_HF_PARAM_KEY_TRANSFORMS)
+
+    @classmethod
+    def state_dict_to_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_to_hf(params, DECODER_HF_PARAM_KEY_TRANSFORMS)
 
     @classmethod
     def from_hf_config(

--- a/curated_transformers/models/hf_hub/__init__.py
+++ b/curated_transformers/models/hf_hub/__init__.py
@@ -1,0 +1,1 @@
+from .mixin import FromHFHub

--- a/curated_transformers/models/hf_hub/conversion.py
+++ b/curated_transformers/models/hf_hub/conversion.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, Dict, List, Mapping, Tuple, Union
 
 from torch import Tensor
 
-from ...util.string import StringTransform
+from ...util.string import StringTransform, StringTransformations
 
 
 def process_hf_keys(

--- a/curated_transformers/models/hf_hub/conversion.py
+++ b/curated_transformers/models/hf_hub/conversion.py
@@ -1,0 +1,101 @@
+from typing import Any, Callable, Dict, List, Mapping, Tuple, Union
+
+from torch import Tensor
+
+from ...util.string import StringTransform
+
+
+def process_hf_keys(
+    model_name: str,
+    hf_config: Dict[str, Any],
+    hf_to_curated: Dict[str, Union[str, Tuple[str, Callable]]],
+    extra_keys: List[str] = [],
+) -> Dict[str, Any]:
+    """
+    Convert Hugging Face configuration keys to keyword arguments for
+    Curated Transformers configuration classes.
+
+    :param model_name:
+        Model name. Only used in exception messages.
+    :param hf_config:
+        Hugging Face model configuration.
+    :param hf_to_curated:
+        Dictionay that maps Hugging Face configuration keys to keyword
+        arguments for a Curated Transformers configuration class. If a value
+        is a tuple, the first tuple element is the name of the keyword
+        argument class and the second tuple element is a conversion function.
+    :param extra_keys:
+        Optional keys for which the Hugging Face configuration key and the
+        keyword argument of the Curated Transformers configuration class is
+        the same.
+    :returns:
+        Dictionary with keyword arguments.
+    """
+    missing_keys = tuple(
+        sorted(set(hf_to_curated.keys()).difference(set(hf_config.keys())))
+    )
+    if len(missing_keys) != 0:
+        raise ValueError(
+            f"Missing keys in Hugging Face {model_name} model config: {missing_keys}"
+        )
+
+    kwargs = {}
+
+    for hf, curated in hf_to_curated.items():
+        if isinstance(curated, tuple):
+            curated, ctor = curated
+        else:
+            ctor = lambda x: x
+
+        kwargs[curated] = ctor(hf_config[hf])
+
+    # Handle config options that are not set in all models.
+    kwargs.update({k: hf_config[k] for k in extra_keys if k in hf_config})
+
+    return kwargs
+
+
+def state_dict_from_hf(
+    params: Mapping[str, Tensor], transforms: List[StringTransform]
+) -> Mapping[str, Tensor]:
+    """
+    Apply transformations to a Hugging Face state dict to make it
+    compatible with Curated Transformer modules.
+
+    :param params:
+        Hugging Face state dict.
+    :param transforms:
+        List of string transformations for the state dict's keys.
+    :returns:
+        Transformed state dict.
+    """
+    out = {}
+    for key, param in params.items():
+        for transform in transforms:
+            key = transform.apply(key)
+        out[key] = param
+    return out
+
+
+def state_dict_to_hf(
+    params: Mapping[str, Tensor], transforms: List[StringTransform]
+) -> Mapping[str, Tensor]:
+    """
+    Apply transformations to a Curated Transformer state dict to make it
+    compatible with Hugging Face modules.
+
+    :param params:
+        Curated Transformer state dict.
+    :param transforms:
+        List of string transformations for the state dict's keys.
+        This must be the same transformations that were used to
+        convert the original Hugging Face state dict.
+    :returns:
+        Transformed state dict.
+    """
+    out = {}
+    for key, param in params.items():
+        for transform in transforms[::-1]:
+            key = transform.revert(key)
+        out[key] = param
+    return out

--- a/curated_transformers/models/hf_hub/conversion.py
+++ b/curated_transformers/models/hf_hub/conversion.py
@@ -20,7 +20,7 @@ def process_hf_keys(
     :param hf_config:
         Hugging Face model configuration.
     :param hf_to_curated:
-        Dictionay that maps Hugging Face configuration keys to keyword
+        Dictionary that maps Hugging Face configuration keys to keyword
         arguments for a Curated Transformers configuration class. If a value
         is a tuple, the first tuple element is the name of the keyword
         argument class and the second tuple element is a conversion function.

--- a/curated_transformers/models/llama/_hf.py
+++ b/curated_transformers/models/llama/_hf.py
@@ -12,39 +12,33 @@ EXTRA_KWARG_KEYS = [ATTENTION_DROPOUT, HIDDEN_DROPOUT]
 # Order-dependent.
 COMMON_HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
     # Attention blocks.
-    StringTransformations.regex_sub_invertible((r".self_attn", ".mha")),
-    StringTransformations.regex_sub_invertible((r".q_proj", ".query")),
-    StringTransformations.regex_sub_invertible((r".k_proj", ".key")),
-    StringTransformations.regex_sub_invertible((r".v_proj", ".value")),
-    StringTransformations.regex_sub_invertible((r".o_proj", ".output")),
+    StringTransformations.sub(".self_attn", ".mha"),
+    StringTransformations.sub(".q_proj", ".query"),
+    StringTransformations.sub(".k_proj", ".key"),
+    StringTransformations.sub(".v_proj", ".value"),
+    StringTransformations.sub(".o_proj", ".output"),
     # Pointwise feedforward
-    StringTransformations.regex_sub_invertible((r".mlp", ".ffn")),
-    StringTransformations.regex_sub_invertible((r".up_proj", ".intermediate")),
-    StringTransformations.regex_sub_invertible((r"ffn.down_proj", "ffn.output")),
-    StringTransformations.regex_sub_invertible((r".gate_proj", ".gate")),
+    StringTransformations.sub(".mlp", ".ffn"),
+    StringTransformations.sub(".up_proj", ".intermediate"),
+    StringTransformations.sub("ffn.down_proj", "ffn.output"),
+    StringTransformations.sub(".gate_proj", ".gate"),
     # RMS norms
-    StringTransformations.regex_sub_invertible(
-        (r".input_layernorm", ".attn_input_layer_norm")
-    ),
-    StringTransformations.regex_sub_invertible(
-        (r".post_attention_layernorm", ".ffn_input_layer_norm")
-    ),
+    StringTransformations.sub(".input_layernorm", ".attn_input_layer_norm"),
+    StringTransformations.sub(".post_attention_layernorm", ".ffn_input_layer_norm"),
     StringTransformations.regex_sub(
         (r"^(decoder\.)?norm\.", "\\1output_layer_norm."),
         (r"^(decoder\.)?output_layer_norm\.", "\\1norm."),
     ),
     # Embeddings
-    StringTransformations.regex_sub_invertible(
-        (r"embed_tokens.", "embeddings.piece_embeddings.")
-    ),
-    StringTransformations.regex_sub_invertible((r"lm_head.", "output_embeddings.")),
+    StringTransformations.sub("embed_tokens.", "embeddings.piece_embeddings."),
+    StringTransformations.sub("lm_head.", "output_embeddings."),
 ]
 
 DECODER_HF_PARAM_KEY_TRANSFORMS = [
     StringTransformations.remove_prefix("model.", reversible=False)
 ] + COMMON_HF_PARAM_KEY_TRANSFORMS
 CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS = [
-    StringTransformations.regex_sub_invertible((r"model.", "decoder."))
+    StringTransformations.sub("model.", "decoder.")
 ] + COMMON_HF_PARAM_KEY_TRANSFORMS
 
 HF_CONFIG_KEY_MAPPING: Dict[str, Union[str, Tuple[str, Callable]]] = {

--- a/curated_transformers/models/llama/_hf.py
+++ b/curated_transformers/models/llama/_hf.py
@@ -1,12 +1,7 @@
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 from ...layers.activations import Activation
-from ...util.string import (
-    StringRemovePrefix,
-    StringSubInvertible,
-    StringSubRegEx,
-    StringTransform,
-)
+from ...util.string import StringTransform, StringTransformations
 from ..hf_hub.conversion import process_hf_keys
 from .config import LlamaConfig
 
@@ -17,33 +12,39 @@ EXTRA_KWARG_KEYS = [ATTENTION_DROPOUT, HIDDEN_DROPOUT]
 # Order-dependent.
 COMMON_HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
     # Attention blocks.
-    StringSubInvertible((r".self_attn", ".mha")),
-    StringSubInvertible((r".q_proj", ".query")),
-    StringSubInvertible((r".k_proj", ".key")),
-    StringSubInvertible((r".v_proj", ".value")),
-    StringSubInvertible((r".o_proj", ".output")),
+    StringTransformations.regex_sub_invertible((r".self_attn", ".mha")),
+    StringTransformations.regex_sub_invertible((r".q_proj", ".query")),
+    StringTransformations.regex_sub_invertible((r".k_proj", ".key")),
+    StringTransformations.regex_sub_invertible((r".v_proj", ".value")),
+    StringTransformations.regex_sub_invertible((r".o_proj", ".output")),
     # Pointwise feedforward
-    StringSubInvertible((r".mlp", ".ffn")),
-    StringSubInvertible((r".up_proj", ".intermediate")),
-    StringSubInvertible((r"ffn.down_proj", "ffn.output")),
-    StringSubInvertible((r".gate_proj", ".gate")),
+    StringTransformations.regex_sub_invertible((r".mlp", ".ffn")),
+    StringTransformations.regex_sub_invertible((r".up_proj", ".intermediate")),
+    StringTransformations.regex_sub_invertible((r"ffn.down_proj", "ffn.output")),
+    StringTransformations.regex_sub_invertible((r".gate_proj", ".gate")),
     # RMS norms
-    StringSubInvertible((r".input_layernorm", ".attn_input_layer_norm")),
-    StringSubInvertible((r".post_attention_layernorm", ".ffn_input_layer_norm")),
-    StringSubRegEx(
+    StringTransformations.regex_sub_invertible(
+        (r".input_layernorm", ".attn_input_layer_norm")
+    ),
+    StringTransformations.regex_sub_invertible(
+        (r".post_attention_layernorm", ".ffn_input_layer_norm")
+    ),
+    StringTransformations.regex_sub(
         (r"^(decoder\.)?norm\.", "\\1output_layer_norm."),
         (r"^(decoder\.)?output_layer_norm\.", "\\1norm."),
     ),
     # Embeddings
-    StringSubInvertible((r"embed_tokens.", "embeddings.piece_embeddings.")),
-    StringSubInvertible((r"lm_head.", "output_embeddings.")),
+    StringTransformations.regex_sub_invertible(
+        (r"embed_tokens.", "embeddings.piece_embeddings.")
+    ),
+    StringTransformations.regex_sub_invertible((r"lm_head.", "output_embeddings.")),
 ]
 
 DECODER_HF_PARAM_KEY_TRANSFORMS = [
-    StringRemovePrefix("model.", reversible=False)
+    StringTransformations.remove_prefix("model.", reversible=False)
 ] + COMMON_HF_PARAM_KEY_TRANSFORMS
 CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS = [
-    StringSubInvertible((r"model.", "decoder."))
+    StringTransformations.regex_sub_invertible((r"model.", "decoder."))
 ] + COMMON_HF_PARAM_KEY_TRANSFORMS
 
 HF_CONFIG_KEY_MAPPING: Dict[str, Union[str, Tuple[str, Callable]]] = {

--- a/curated_transformers/models/llama/_hf.py
+++ b/curated_transformers/models/llama/_hf.py
@@ -1,7 +1,12 @@
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 from ...layers.activations import Activation
-from ...util.string import StringTransform, StrLStrip, StrSub, StrSubInv
+from ...util.string import (
+    StringRemovePrefix,
+    StringSubInvertible,
+    StringSubRegEx,
+    StringTransform,
+)
 from ..hf_hub.conversion import process_hf_keys
 from .config import LlamaConfig
 
@@ -12,33 +17,33 @@ EXTRA_KWARG_KEYS = [ATTENTION_DROPOUT, HIDDEN_DROPOUT]
 # Order-dependent.
 COMMON_HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
     # Attention blocks.
-    StrSubInv((r".self_attn", ".mha")),
-    StrSubInv((r".q_proj", ".query")),
-    StrSubInv((r".k_proj", ".key")),
-    StrSubInv((r".v_proj", ".value")),
-    StrSubInv((r".o_proj", ".output")),
+    StringSubInvertible((r".self_attn", ".mha")),
+    StringSubInvertible((r".q_proj", ".query")),
+    StringSubInvertible((r".k_proj", ".key")),
+    StringSubInvertible((r".v_proj", ".value")),
+    StringSubInvertible((r".o_proj", ".output")),
     # Pointwise feedforward
-    StrSubInv((r".mlp", ".ffn")),
-    StrSubInv((r".up_proj", ".intermediate")),
-    StrSubInv((r"ffn.down_proj", "ffn.output")),
-    StrSubInv((r".gate_proj", ".gate")),
+    StringSubInvertible((r".mlp", ".ffn")),
+    StringSubInvertible((r".up_proj", ".intermediate")),
+    StringSubInvertible((r"ffn.down_proj", "ffn.output")),
+    StringSubInvertible((r".gate_proj", ".gate")),
     # RMS norms
-    StrSubInv((r".input_layernorm", ".attn_input_layer_norm")),
-    StrSubInv((r".post_attention_layernorm", ".ffn_input_layer_norm")),
-    StrSub(
+    StringSubInvertible((r".input_layernorm", ".attn_input_layer_norm")),
+    StringSubInvertible((r".post_attention_layernorm", ".ffn_input_layer_norm")),
+    StringSubRegEx(
         (r"^(decoder\.)?norm\.", "\\1output_layer_norm."),
         (r"^(decoder\.)?output_layer_norm\.", "\\1norm."),
     ),
     # Embeddings
-    StrSubInv((r"embed_tokens.", "embeddings.piece_embeddings.")),
-    StrSubInv((r"lm_head.", "output_embeddings.")),
+    StringSubInvertible((r"embed_tokens.", "embeddings.piece_embeddings.")),
+    StringSubInvertible((r"lm_head.", "output_embeddings.")),
 ]
 
 DECODER_HF_PARAM_KEY_TRANSFORMS = [
-    StrLStrip("model.", reversible=False)
+    StringRemovePrefix("model.", reversible=False)
 ] + COMMON_HF_PARAM_KEY_TRANSFORMS
 CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS = [
-    StrSubInv((r"model.", "decoder."))
+    StringSubInvertible((r"model.", "decoder."))
 ] + COMMON_HF_PARAM_KEY_TRANSFORMS
 
 HF_CONFIG_KEY_MAPPING: Dict[str, Union[str, Tuple[str, Callable]]] = {

--- a/curated_transformers/models/llama/causal_lm.py
+++ b/curated_transformers/models/llama/causal_lm.py
@@ -6,8 +6,9 @@ from torch.nn import Linear
 
 from ...quantization import Quantizable
 from ..hf_hub import FromHFHub
+from ..hf_hub.conversion import state_dict_from_hf, state_dict_to_hf
 from ..transformer import TransformerCausalLM
-from ._hf import convert_hf_config, convert_hf_state_dict
+from ._hf import CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS, convert_hf_config
 from .config import LlamaConfig
 from .decoder import LlamaDecoder
 
@@ -47,8 +48,16 @@ class LlamaCausalLM(TransformerCausalLM[LlamaConfig], FromHFHub, Quantizable):
         )
 
     @classmethod
-    def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):
-        return convert_hf_state_dict(cls, params)
+    def state_dict_from_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_from_hf(params, CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS)
+
+    @classmethod
+    def state_dict_to_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_to_hf(params, CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS)
 
     @classmethod
     def from_hf_config(

--- a/curated_transformers/models/llama/decoder.py
+++ b/curated_transformers/models/llama/decoder.py
@@ -18,8 +18,9 @@ from ...layers.transformer import (
     TransformerLayerNorms,
 )
 from ..hf_hub import FromHFHub
+from ..hf_hub.conversion import state_dict_from_hf, state_dict_to_hf
 from ..transformer import TransformerDecoder
-from ._hf import convert_hf_config, convert_hf_state_dict
+from ._hf import DECODER_HF_PARAM_KEY_TRANSFORMS, convert_hf_config
 from .config import LlamaConfig
 
 # Only provided as typing.Self in Python 3.11+.
@@ -120,8 +121,16 @@ class LlamaDecoder(TransformerDecoder[LlamaConfig], FromHFHub):
         )
 
     @classmethod
-    def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):
-        return convert_hf_state_dict(cls, params)
+    def state_dict_from_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_from_hf(params, DECODER_HF_PARAM_KEY_TRANSFORMS)
+
+    @classmethod
+    def state_dict_to_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_to_hf(params, DECODER_HF_PARAM_KEY_TRANSFORMS)
 
     @classmethod
     def from_hf_config(

--- a/curated_transformers/models/mpt/_hf.py
+++ b/curated_transformers/models/mpt/_hf.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, Dict, List, Tuple, Union
 
-from ...util.string import StringRemovePrefix, StringSubInvertible, StringTransform
+from ...util.string import StringTransform, StringTransformations
 from ..hf_hub.conversion import process_hf_keys
 from .config import MPTConfig
 
@@ -10,26 +10,28 @@ EXTRA_KWARG_KEYS = [ATTENTION_DROPOUT, HIDDEN_DROPOUT]
 
 # Order-dependent.
 COMMON_HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
-    StringSubInvertible((r"transformer", "decoder")),
-    StringSubInvertible((r"blocks", "layers")),
+    StringTransformations.regex_sub_invertible((r"transformer", "decoder")),
+    StringTransformations.regex_sub_invertible((r"blocks", "layers")),
     # Attention blocks.
-    StringSubInvertible((r".attn", ".mha")),
-    StringSubInvertible((r".Wqkv", ".input")),
-    StringSubInvertible((r".out_proj", ".output")),
+    StringTransformations.regex_sub_invertible((r".attn", ".mha")),
+    StringTransformations.regex_sub_invertible((r".Wqkv", ".input")),
+    StringTransformations.regex_sub_invertible((r".out_proj", ".output")),
     # Pointwise feedforward.
-    StringSubInvertible((r".up_proj", ".intermediate")),
-    StringSubInvertible((r"ffn.down_proj", "ffn.output")),
+    StringTransformations.regex_sub_invertible((r".up_proj", ".intermediate")),
+    StringTransformations.regex_sub_invertible((r"ffn.down_proj", "ffn.output")),
     # Layer norms.
-    StringSubInvertible((r".norm_1", ".attn_input_layer_norm")),
-    StringSubInvertible((r".norm_2", ".ffn_input_layer_norm")),
-    StringSubInvertible((r"norm_f.", "output_layer_norm.")),
+    StringTransformations.regex_sub_invertible((r".norm_1", ".attn_input_layer_norm")),
+    StringTransformations.regex_sub_invertible((r".norm_2", ".ffn_input_layer_norm")),
+    StringTransformations.regex_sub_invertible((r"norm_f.", "output_layer_norm.")),
     # Embeddings.
-    StringSubInvertible((r"wte.", "embeddings.piece_embeddings.")),
+    StringTransformations.regex_sub_invertible(
+        (r"wte.", "embeddings.piece_embeddings.")
+    ),
 ]
 
 
 DECODER_HF_PARAM_KEY_TRANSFORMS = [
-    StringRemovePrefix("transformer.", reversible=False)
+    StringTransformations.remove_prefix("transformer.", reversible=False)
 ] + COMMON_HF_PARAM_KEY_TRANSFORMS
 CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS = COMMON_HF_PARAM_KEY_TRANSFORMS
 

--- a/curated_transformers/models/mpt/_hf.py
+++ b/curated_transformers/models/mpt/_hf.py
@@ -10,23 +10,21 @@ EXTRA_KWARG_KEYS = [ATTENTION_DROPOUT, HIDDEN_DROPOUT]
 
 # Order-dependent.
 COMMON_HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
-    StringTransformations.regex_sub_invertible((r"transformer", "decoder")),
-    StringTransformations.regex_sub_invertible((r"blocks", "layers")),
+    StringTransformations.sub("transformer", "decoder"),
+    StringTransformations.sub("blocks", "layers"),
     # Attention blocks.
-    StringTransformations.regex_sub_invertible((r".attn", ".mha")),
-    StringTransformations.regex_sub_invertible((r".Wqkv", ".input")),
-    StringTransformations.regex_sub_invertible((r".out_proj", ".output")),
+    StringTransformations.sub(".attn", ".mha"),
+    StringTransformations.sub(".Wqkv", ".input"),
+    StringTransformations.sub(".out_proj", ".output"),
     # Pointwise feedforward.
-    StringTransformations.regex_sub_invertible((r".up_proj", ".intermediate")),
-    StringTransformations.regex_sub_invertible((r"ffn.down_proj", "ffn.output")),
+    StringTransformations.sub(".up_proj", ".intermediate"),
+    StringTransformations.sub("ffn.down_proj", "ffn.output"),
     # Layer norms.
-    StringTransformations.regex_sub_invertible((r".norm_1", ".attn_input_layer_norm")),
-    StringTransformations.regex_sub_invertible((r".norm_2", ".ffn_input_layer_norm")),
-    StringTransformations.regex_sub_invertible((r"norm_f.", "output_layer_norm.")),
+    StringTransformations.sub(".norm_1", ".attn_input_layer_norm"),
+    StringTransformations.sub(".norm_2", ".ffn_input_layer_norm"),
+    StringTransformations.sub("norm_f.", "output_layer_norm."),
     # Embeddings.
-    StringTransformations.regex_sub_invertible(
-        (r"wte.", "embeddings.piece_embeddings.")
-    ),
+    StringTransformations.sub("wte.", "embeddings.piece_embeddings."),
 ]
 
 

--- a/curated_transformers/models/mpt/_hf.py
+++ b/curated_transformers/models/mpt/_hf.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, Dict, List, Tuple, Union
 
-from ...util.string import StringTransform, StrLStrip, StrSubInv
+from ...util.string import StringRemovePrefix, StringSubInvertible, StringTransform
 from ..hf_hub.conversion import process_hf_keys
 from .config import MPTConfig
 
@@ -10,26 +10,26 @@ EXTRA_KWARG_KEYS = [ATTENTION_DROPOUT, HIDDEN_DROPOUT]
 
 # Order-dependent.
 COMMON_HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
-    StrSubInv((r"transformer", "decoder")),
-    StrSubInv((r"blocks", "layers")),
+    StringSubInvertible((r"transformer", "decoder")),
+    StringSubInvertible((r"blocks", "layers")),
     # Attention blocks.
-    StrSubInv((r".attn", ".mha")),
-    StrSubInv((r".Wqkv", ".input")),
-    StrSubInv((r".out_proj", ".output")),
+    StringSubInvertible((r".attn", ".mha")),
+    StringSubInvertible((r".Wqkv", ".input")),
+    StringSubInvertible((r".out_proj", ".output")),
     # Pointwise feedforward.
-    StrSubInv((r".up_proj", ".intermediate")),
-    StrSubInv((r"ffn.down_proj", "ffn.output")),
+    StringSubInvertible((r".up_proj", ".intermediate")),
+    StringSubInvertible((r"ffn.down_proj", "ffn.output")),
     # Layer norms.
-    StrSubInv((r".norm_1", ".attn_input_layer_norm")),
-    StrSubInv((r".norm_2", ".ffn_input_layer_norm")),
-    StrSubInv((r"norm_f.", "output_layer_norm.")),
+    StringSubInvertible((r".norm_1", ".attn_input_layer_norm")),
+    StringSubInvertible((r".norm_2", ".ffn_input_layer_norm")),
+    StringSubInvertible((r"norm_f.", "output_layer_norm.")),
     # Embeddings.
-    StrSubInv((r"wte.", "embeddings.piece_embeddings.")),
+    StringSubInvertible((r"wte.", "embeddings.piece_embeddings.")),
 ]
 
 
 DECODER_HF_PARAM_KEY_TRANSFORMS = [
-    StrLStrip("transformer.", reversible=False)
+    StringRemovePrefix("transformer.", reversible=False)
 ] + COMMON_HF_PARAM_KEY_TRANSFORMS
 CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS = COMMON_HF_PARAM_KEY_TRANSFORMS
 

--- a/curated_transformers/models/mpt/causal_lm.py
+++ b/curated_transformers/models/mpt/causal_lm.py
@@ -9,9 +9,10 @@ from ...layers.attention import AttentionMask
 from ...layers.cache import KeyValueCache
 from ...quantization import Quantizable
 from ..hf_hub import FromHFHub
+from ..hf_hub.conversion import state_dict_from_hf, state_dict_to_hf
 from ..output import CausalLMOutputWithCache
 from ..transformer import TransformerCausalLM
-from ._hf import convert_hf_config, convert_hf_state_dict
+from ._hf import CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS, convert_hf_config
 from .config import MPTConfig
 from .decoder import MPTDecoder
 
@@ -84,8 +85,16 @@ class MPTCausalLM(TransformerCausalLM[MPTConfig], FromHFHub, Quantizable):
         )
 
     @classmethod
-    def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):
-        return convert_hf_state_dict(cls, params)
+    def state_dict_from_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_from_hf(params, CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS)
+
+    @classmethod
+    def state_dict_to_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_to_hf(params, CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS)
 
     @classmethod
     def from_hf_config(

--- a/curated_transformers/models/mpt/decoder.py
+++ b/curated_transformers/models/mpt/decoder.py
@@ -21,8 +21,9 @@ from ...layers.transformer import (
     TransformerLayerNorms,
 )
 from ..hf_hub import FromHFHub
+from ..hf_hub.conversion import state_dict_from_hf, state_dict_to_hf
 from ..transformer import TransformerDecoder
-from ._hf import convert_hf_config, convert_hf_state_dict
+from ._hf import DECODER_HF_PARAM_KEY_TRANSFORMS, convert_hf_config
 from .config import MPTConfig
 
 # Only provided as typing.Self in Python 3.11+.
@@ -120,8 +121,16 @@ class MPTDecoder(TransformerDecoder[MPTConfig], FromHFHub):
         self.output_layer_norm = layer_norm()
 
     @classmethod
-    def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):
-        return convert_hf_state_dict(cls, params)
+    def state_dict_from_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_from_hf(params, DECODER_HF_PARAM_KEY_TRANSFORMS)
+
+    @classmethod
+    def state_dict_to_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_to_hf(params, DECODER_HF_PARAM_KEY_TRANSFORMS)
 
     @classmethod
     def from_hf_config(

--- a/curated_transformers/models/roberta/_hf.py
+++ b/curated_transformers/models/roberta/_hf.py
@@ -20,16 +20,12 @@ HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
         (r"\.attention\.self\.(query|key|value)", ".mha.\\1"),
         (r"\.mha\.(query|key|value)", ".attention.self.\\1"),
     ),
-    StringTransformations.regex_sub_invertible(
-        (r".attention.output.dense", ".mha.output")
-    ),
-    StringTransformations.regex_sub_invertible(
-        (r".attention.output.LayerNorm", ".attn_residual_layer_norm")
+    StringTransformations.sub(".attention.output.dense", ".mha.output"),
+    StringTransformations.sub(
+        r".attention.output.LayerNorm", ".attn_residual_layer_norm"
     ),
     # Pointwise feed-forward layers.
-    StringTransformations.regex_sub_invertible(
-        (r".intermediate.dense", ".ffn.intermediate")
-    ),
+    StringTransformations.sub(".intermediate.dense", ".ffn.intermediate"),
     StringTransformations.regex_sub(
         (r"(\.\d+)\.output\.LayerNorm", "\\1.ffn_residual_layer_norm"),
         (r"(\.\d+)\.ffn_residual_layer_norm", "\\1.output.LayerNorm"),

--- a/curated_transformers/models/roberta/_hf.py
+++ b/curated_transformers/models/roberta/_hf.py
@@ -1,47 +1,59 @@
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 from ...layers.activations import Activation
-from ...util.string import StringTransform, StrLStrip, StrRepl, StrSub, StrSubInv
+from ...util.string import (
+    StringRemovePrefix,
+    StringReplace,
+    StringSubInvertible,
+    StringSubRegEx,
+    StringTransform,
+)
 from ..hf_hub.conversion import process_hf_keys
 from .config import RoBERTaConfig
 
 # Order-dependent.
 HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
     # Prefixes.
-    StrLStrip("roberta.", reversible=False),
-    StrSub(
+    StringRemovePrefix("roberta.", reversible=False),
+    StringSubRegEx(
         (r"^encoder\.(layer\.)", "\\1"),
         (r"^(layer\.)", "encoder.\\1"),
     ),
     # Layers.
-    StrSub((r"^layer", "layers"), (r"^layers", "layer")),
+    StringSubRegEx((r"^layer", "layers"), (r"^layers", "layer")),
     # Attention blocks.
-    StrSub(
+    StringSubRegEx(
         (r"\.attention\.self\.(query|key|value)", ".mha.\\1"),
         (r"\.mha\.(query|key|value)", ".attention.self.\\1"),
     ),
-    StrSubInv((r".attention.output.dense", ".mha.output")),
-    StrSubInv((r".attention.output.LayerNorm", ".attn_residual_layer_norm")),
+    StringSubInvertible((r".attention.output.dense", ".mha.output")),
+    StringSubInvertible((r".attention.output.LayerNorm", ".attn_residual_layer_norm")),
     # Pointwise feed-forward layers.
-    StrSubInv((r".intermediate.dense", ".ffn.intermediate")),
-    StrSub(
+    StringSubInvertible((r".intermediate.dense", ".ffn.intermediate")),
+    StringSubRegEx(
         (r"(\.\d+)\.output\.LayerNorm", "\\1.ffn_residual_layer_norm"),
         (r"(\.\d+)\.ffn_residual_layer_norm", "\\1.output.LayerNorm"),
     ),
-    StrSub(
+    StringSubRegEx(
         (r"(\.\d+)\.output\.dense", "\\1.ffn.output"),
         (r"(\.\d+)\.ffn\.output", "\\1.output.dense"),
     ),
     # Embeddings.
-    StrRepl("embeddings.word_embeddings.weight", "embeddings.piece_embeddings.weight"),
-    StrRepl(
+    StringReplace(
+        "embeddings.word_embeddings.weight", "embeddings.piece_embeddings.weight"
+    ),
+    StringReplace(
         "embeddings.token_type_embeddings.weight", "embeddings.type_embeddings.weight"
     ),
-    StrRepl(
+    StringReplace(
         "embeddings.position_embeddings.weight", "embeddings.position_embeddings.weight"
     ),
-    StrRepl("embeddings.LayerNorm.weight", "embeddings.embed_output_layer_norm.weight"),
-    StrRepl("embeddings.LayerNorm.bias", "embeddings.embed_output_layer_norm.bias"),
+    StringReplace(
+        "embeddings.LayerNorm.weight", "embeddings.embed_output_layer_norm.weight"
+    ),
+    StringReplace(
+        "embeddings.LayerNorm.bias", "embeddings.embed_output_layer_norm.bias"
+    ),
 ]
 
 HF_CONFIG_KEY_MAPPING: Dict[str, Union[str, Tuple[str, Callable]]] = {

--- a/curated_transformers/models/roberta/encoder.py
+++ b/curated_transformers/models/roberta/encoder.py
@@ -15,8 +15,9 @@ from ...layers.transformer import (
     TransformerLayerNorms,
 )
 from ..hf_hub import FromHFHub
+from ..hf_hub.conversion import state_dict_from_hf, state_dict_to_hf
 from ..transformer import TransformerEncoder
-from ._hf import convert_hf_config, convert_hf_state_dict
+from ._hf import HF_PARAM_KEY_TRANSFORMS, convert_hf_config
 from .config import RoBERTaConfig
 from .embeddings import RoBERTaEmbeddings
 
@@ -105,8 +106,16 @@ class RoBERTaEncoder(TransformerEncoder[RoBERTaConfig], FromHFHub):
         )
 
     @classmethod
-    def convert_hf_state_dict(cls, params: Mapping[str, Tensor]):
-        return convert_hf_state_dict(params)
+    def state_dict_from_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_from_hf(params, HF_PARAM_KEY_TRANSFORMS)
+
+    @classmethod
+    def state_dict_to_hf(
+        cls: Type[Self], params: Mapping[str, Tensor]
+    ) -> Mapping[str, Tensor]:
+        return state_dict_to_hf(params, HF_PARAM_KEY_TRANSFORMS)
 
     @classmethod
     def from_hf_config(

--- a/curated_transformers/tests/models/albert/test_encoder.py
+++ b/curated_transformers/tests/models/albert/test_encoder.py
@@ -4,7 +4,11 @@ from curated_transformers.models.albert import ALBERTConfig, ALBERTEncoder
 
 from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
-from ..util import JITMethod, assert_encoder_output_equals_hf
+from ..util import (
+    JITMethod,
+    assert_encoder_output_equals_hf,
+    assert_model_hf_serialization_roundtrip,
+)
 
 
 def test_rejects_incorrect_number_of_groups():
@@ -51,4 +55,12 @@ def test_encoder_with_torchscript_trace(torch_device, with_torch_sdp):
         torch_device,
         jit_method=JITMethod.TorchScriptTrace,
         with_torch_sdp=with_torch_sdp,
+    )
+
+
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_encoder_hf_serializtion_roundtrip(torch_device):
+    assert_model_hf_serialization_roundtrip(
+        ALBERTEncoder, "explosion-testing/albert-test", torch_device
     )

--- a/curated_transformers/tests/models/bert/test_encoder.py
+++ b/curated_transformers/tests/models/bert/test_encoder.py
@@ -4,7 +4,11 @@ from curated_transformers.models.bert.encoder import BERTEncoder
 
 from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
-from ..util import JITMethod, assert_encoder_output_equals_hf
+from ..util import (
+    JITMethod,
+    assert_encoder_output_equals_hf,
+    assert_model_hf_serialization_roundtrip,
+)
 
 
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
@@ -45,4 +49,12 @@ def test_encoder_with_torchscript_trace(torch_device, with_torch_sdp):
         torch_device,
         jit_method=JITMethod.TorchScriptTrace,
         with_torch_sdp=with_torch_sdp,
+    )
+
+
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_encoder_hf_serializtion_roundtrip(torch_device):
+    assert_model_hf_serialization_roundtrip(
+        BERTEncoder, "explosion-testing/bert-test", torch_device
     )

--- a/curated_transformers/tests/models/camembert/test_encoder.py
+++ b/curated_transformers/tests/models/camembert/test_encoder.py
@@ -4,7 +4,11 @@ from curated_transformers.models.camembert.encoder import CamemBERTEncoder
 
 from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
-from ..util import JITMethod, assert_encoder_output_equals_hf
+from ..util import (
+    JITMethod,
+    assert_encoder_output_equals_hf,
+    assert_model_hf_serialization_roundtrip,
+)
 
 
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
@@ -45,4 +49,12 @@ def test_encoder_with_torchscript_trace(torch_device, with_torch_sdp):
         torch_device,
         jit_method=JITMethod.TorchScriptTrace,
         with_torch_sdp=with_torch_sdp,
+    )
+
+
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_encoder_hf_serializtion_roundtrip(torch_device):
+    assert_model_hf_serialization_roundtrip(
+        CamemBERTEncoder, "explosion-testing/camembert-test", torch_device
     )

--- a/curated_transformers/tests/models/gpt_neox/test_causal_lm.py
+++ b/curated_transformers/tests/models/gpt_neox/test_causal_lm.py
@@ -4,7 +4,11 @@ from curated_transformers.models.gpt_neox.causal_lm import GPTNeoXCausalLM
 
 from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
-from ..util import JITMethod, assert_causal_lm_output_equals_hf
+from ..util import (
+    JITMethod,
+    assert_causal_lm_output_equals_hf,
+    assert_model_hf_serialization_roundtrip,
+)
 
 
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
@@ -45,4 +49,14 @@ def test_causal_lm_with_torchscript_trace(torch_device, with_torch_sdp):
         torch_device,
         jit_method=JITMethod.TorchScriptTrace,
         with_torch_sdp=with_torch_sdp,
+    )
+
+
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_causal_lm_hf_serializtion_roundtrip(torch_device):
+    assert_model_hf_serialization_roundtrip(
+        GPTNeoXCausalLM,
+        "trl-internal-testing/tiny-random-GPTNeoXForCausalLM",
+        torch_device,
     )

--- a/curated_transformers/tests/models/gpt_neox/test_decoder.py
+++ b/curated_transformers/tests/models/gpt_neox/test_decoder.py
@@ -4,7 +4,11 @@ from curated_transformers.models.gpt_neox.decoder import GPTNeoXDecoder
 
 from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
-from ..util import JITMethod, assert_decoder_output_equals_hf
+from ..util import (
+    JITMethod,
+    assert_decoder_output_equals_hf,
+    assert_model_hf_serialization_roundtrip,
+)
 
 
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
@@ -53,4 +57,14 @@ def test_decoder_with_torchscript_trace(torch_device, with_torch_sdp):
         with_positions=True,
         jit_method=JITMethod.TorchScriptTrace,
         with_torch_sdp=with_torch_sdp,
+    )
+
+
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_decoder_hf_serializtion_roundtrip(torch_device):
+    assert_model_hf_serialization_roundtrip(
+        GPTNeoXDecoder,
+        "trl-internal-testing/tiny-random-GPTNeoXForCausalLM",
+        torch_device,
     )

--- a/curated_transformers/tests/models/llama/test_causal_lm.py
+++ b/curated_transformers/tests/models/llama/test_causal_lm.py
@@ -4,7 +4,11 @@ from curated_transformers.models.llama.causal_lm import LlamaCausalLM
 
 from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
-from ..util import JITMethod, assert_causal_lm_output_equals_hf
+from ..util import (
+    JITMethod,
+    assert_causal_lm_output_equals_hf,
+    assert_model_hf_serialization_roundtrip,
+)
 
 LLAMA_TEST_MODELS = [
     "trl-internal-testing/tiny-random-LlamaForCausalLM",
@@ -55,3 +59,10 @@ def test_causal_lm_with_torchscript_trace(torch_device, model, with_torch_sdp):
         jit_method=JITMethod.TorchScriptTrace,
         with_torch_sdp=with_torch_sdp,
     )
+
+
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.parametrize("model", LLAMA_TEST_MODELS)
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_causal_lm_hf_serializtion_roundtrip(model, torch_device):
+    assert_model_hf_serialization_roundtrip(LlamaCausalLM, model, torch_device)

--- a/curated_transformers/tests/models/llama/test_decoder.py
+++ b/curated_transformers/tests/models/llama/test_decoder.py
@@ -4,7 +4,11 @@ from curated_transformers.models.llama.decoder import LlamaDecoder
 
 from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
-from ..util import JITMethod, assert_decoder_output_equals_hf
+from ..util import (
+    JITMethod,
+    assert_decoder_output_equals_hf,
+    assert_model_hf_serialization_roundtrip,
+)
 
 LLAMA_TEST_MODELS = [
     "trl-internal-testing/tiny-random-LlamaForCausalLM",
@@ -52,3 +56,10 @@ def test_decoder_with_torchscript_trace(torch_device, model, with_torch_sdp):
         jit_method=JITMethod.TorchScriptTrace,
         with_torch_sdp=with_torch_sdp,
     )
+
+
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.parametrize("model", LLAMA_TEST_MODELS)
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_decoder_hf_serializtion_roundtrip(model, torch_device):
+    assert_model_hf_serialization_roundtrip(LlamaDecoder, model, torch_device)

--- a/curated_transformers/tests/models/mpt/test_causal_lm.py
+++ b/curated_transformers/tests/models/mpt/test_causal_lm.py
@@ -4,7 +4,11 @@ from curated_transformers.models.mpt.causal_lm import MPTCausalLM
 
 from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
-from ..util import JITMethod, assert_causal_lm_output_equals_hf
+from ..util import (
+    JITMethod,
+    assert_causal_lm_output_equals_hf,
+    assert_model_hf_serialization_roundtrip,
+)
 
 
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
@@ -45,4 +49,12 @@ def test_causal_lm_with_torchscript_trace(torch_device, with_torch_sdp):
         torch_device,
         jit_method=JITMethod.TorchScriptTrace,
         with_torch_sdp=with_torch_sdp,
+    )
+
+
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_causal_lm_hf_serializtion_roundtrip(torch_device):
+    assert_model_hf_serialization_roundtrip(
+        MPTCausalLM, "explosion-testing/mpt-test", torch_device
     )

--- a/curated_transformers/tests/models/mpt/test_decoder.py
+++ b/curated_transformers/tests/models/mpt/test_decoder.py
@@ -4,7 +4,11 @@ from curated_transformers.models.mpt.decoder import MPTDecoder
 
 from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
-from ..util import JITMethod, assert_decoder_output_equals_hf
+from ..util import (
+    JITMethod,
+    assert_decoder_output_equals_hf,
+    assert_model_hf_serialization_roundtrip,
+)
 
 
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
@@ -55,4 +59,12 @@ def test_decoder_with_torchscript_trace(torch_device, with_torch_sdp):
         with_positions=False,
         jit_method=JITMethod.TorchScriptTrace,
         with_torch_sdp=with_torch_sdp,
+    )
+
+
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_decoder_hf_serializtion_roundtrip(torch_device):
+    assert_model_hf_serialization_roundtrip(
+        MPTDecoder, "explosion-testing/mpt-test", torch_device
     )

--- a/curated_transformers/tests/models/roberta/test_encoder.py
+++ b/curated_transformers/tests/models/roberta/test_encoder.py
@@ -4,7 +4,11 @@ from curated_transformers.models.roberta.encoder import RoBERTaEncoder
 
 from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
-from ..util import JITMethod, assert_encoder_output_equals_hf
+from ..util import (
+    JITMethod,
+    assert_encoder_output_equals_hf,
+    assert_model_hf_serialization_roundtrip,
+)
 
 
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
@@ -45,4 +49,12 @@ def test_encoder_with_torchscript_trace(torch_device, with_torch_sdp):
         torch_device,
         jit_method=JITMethod.TorchScriptTrace,
         with_torch_sdp=with_torch_sdp,
+    )
+
+
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_encoder_hf_serializtion_roundtrip(torch_device):
+    assert_model_hf_serialization_roundtrip(
+        RoBERTaEncoder, "explosion-testing/roberta-test", torch_device
     )

--- a/curated_transformers/tests/models/xlm_roberta/test_encoder.py
+++ b/curated_transformers/tests/models/xlm_roberta/test_encoder.py
@@ -4,7 +4,11 @@ from curated_transformers.models.xlm_roberta.encoder import XLMREncoder
 
 from ...compat import has_hf_transformers, has_torch_compile
 from ...conftest import TORCH_DEVICES
-from ..util import JITMethod, assert_encoder_output_equals_hf
+from ..util import (
+    JITMethod,
+    assert_encoder_output_equals_hf,
+    assert_model_hf_serialization_roundtrip,
+)
 
 
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
@@ -45,4 +49,12 @@ def test_encoder_with_torchscript_trace(torch_device, with_torch_sdp):
         torch_device,
         jit_method=JITMethod.TorchScriptTrace,
         with_torch_sdp=with_torch_sdp,
+    )
+
+
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_encoder_hf_serializtion_roundtrip(torch_device):
+    assert_model_hf_serialization_roundtrip(
+        XLMREncoder, "explosion-testing/xlm-roberta-test", torch_device
     )

--- a/curated_transformers/util/string.py
+++ b/curated_transformers/util/string.py
@@ -78,7 +78,8 @@ class StringSubRegEx(StringTransform):
         return re.sub(self.forward[0], self.forward[1], string)
 
     def _revert(self, string: str) -> str:
-        assert self.backward is not None
+        if self.backward is None:
+            raise ValueError("Attempting to revert an irreversible string transform")
         return re.sub(self.backward[0], self.backward[1], string)
 
 

--- a/curated_transformers/util/string.py
+++ b/curated_transformers/util/string.py
@@ -46,6 +46,79 @@ class StringTransform(ABC):
             return string
 
 
+class StringTransformations:
+    """
+    Provides factory methods for different string transformations.
+    """
+
+    @staticmethod
+    def regex_sub(
+        forward: Tuple[str, str], backward: Optional[Tuple[str, str]]
+    ) -> StringTransform:
+        """
+        Factory method to construct a string substitution transform
+        using regular expressions.
+
+        :param forward:
+            Tuple where the first string is a RegEx pattern
+            and the second the replacement.
+
+            This operation is performed when the :meth:`.apply`
+            method is invoked.
+        :param backward:
+            Optional tuple where the first string is a RegEx pattern
+            and the second the replacement.
+
+            This operation is performed when the :meth:`.revert`
+            method is invoked. If ``None``, it is a no-op.
+        """
+        return StringSubRegEx(forward, backward)
+
+    @staticmethod
+    def regex_sub_invertible(forward: Tuple[str, str]) -> StringTransform:
+        """
+        Factory method to construct a string substitution transform
+        using regular expressions whose backward transformation can
+        be automatically derived from the forward transformation.
+
+        :param forward:
+            Tuple where the first string is string to match
+            and the second the replacement, neither of which
+            can contain RegEx meta-characters.
+        """
+        return StringSubInvertible(forward)
+
+    @staticmethod
+    def replace(
+        replacee: str, replacement: str, *, reversible: bool = True
+    ) -> StringTransform:
+        """
+        Factory method to construct a string replacement transform.
+
+        :param replacee:
+            The full string to be replaced.
+        :param replacement:
+            The replacement string.
+        :param reversible:
+            If the reverse transformation is to
+            be performed.
+        """
+        return StringReplace(replacee, replacement, reversible=reversible)
+
+    @staticmethod
+    def remove_prefix(prefix: str, *, reversible: bool = True) -> StringTransform:
+        """
+        Factory method to construct a string prefix removal transform.
+
+        :param prefix:
+            Prefix to be removed.
+        :param reversible:
+            If the reverse transformation is to
+            be performed.
+        """
+        return StringRemovePrefix(prefix, reversible=reversible)
+
+
 class StringSubRegEx(StringTransform):
     """
     Substitute a substring with another string using
@@ -117,6 +190,9 @@ class StringReplace(StringTransform):
             The full string to be replaced.
         :param replacement:
             The replacement string.
+        :param reversible:
+            If the reverse transformation is to
+            be performed.
         """
         super().__init__(reversible)
         self.replacee = replacee
@@ -145,7 +221,10 @@ class StringRemovePrefix(StringTransform):
         Construct a reversible left strip.
 
         :param prefix:
-            Prefix to be stripped.
+            Prefix to be removed.
+        :param reversible:
+            If the reverse transformation is to
+            be performed.
         """
 
         super().__init__(reversible)

--- a/curated_transformers/util/string.py
+++ b/curated_transformers/util/string.py
@@ -1,0 +1,140 @@
+import re
+from abc import ABC, abstractmethod
+from typing import Optional, Tuple
+
+
+class StringTransform(ABC):
+    """
+    Base class for reversible string transformations.
+    """
+
+    def __init__(self, reversible: bool = True):
+        super().__init__()
+        self._reversible = reversible
+
+    @abstractmethod
+    def _apply(self, string: str) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _revert(self, string: str) -> str:
+        raise NotImplementedError
+
+    def apply(self, string: str) -> str:
+        """
+        Applies the transformation to the given string.
+
+        :param string:
+            String to transform.
+        :returns:
+            Transformed string.
+        """
+        return self._apply(string)
+
+    def revert(self, string: str) -> str:
+        """
+        Reverts the previously applied transformation of the given string.
+
+        :param string:
+            Previously transformed string.
+        :returns:
+            Reverted string.
+        """
+        if self._reversible:
+            return self._revert(string)
+        else:
+            return string
+
+
+class StrSub(StringTransform):
+    """
+    Substitute a substring with another string.
+    """
+
+    def __init__(self, forward: Tuple[str, str], backward: Optional[Tuple[str, str]]):
+        """
+        Construct a reversible substitution.
+
+        :param forward:
+            Tuple where the first string is a RegEx pattern
+            and the second the replacement.
+
+            This operation is performed when the :meth:`.apply`
+            method is invoked.
+        :param backward:
+            Optional tuple where the first string is a RegEx pattern
+            and the second the replacement.
+
+            This operation is performed when the :meth:`.revert`
+            method is invoked. If ``None``, it is a no-op.
+        """
+        super().__init__(backward is not None)
+
+        self.forward = forward
+        self.backward = backward
+
+    def _apply(self, string: str) -> str:
+        return re.sub(self.forward[0], self.forward[1], string)
+
+    def _revert(self, string: str) -> str:
+        assert self.backward is not None
+        return re.sub(self.backward[0], self.backward[1], string)
+
+
+class StrSubInv(StrSub):
+    """
+    A substitution whose backward transformation can be
+    automatically derived from the forward transformation.
+    """
+
+    def __init__(self, forward: Tuple[str, str]):
+        """
+        Construct a reversible (and invertible) substitution.
+
+        :param forward:
+            Tuple where the first string is string to match
+            and the second the replacement, neither of which
+            can contain RegEx meta-characters.
+        """
+        super().__init__(
+            forward=(f"{re.escape(forward[0])}", forward[1]),
+            backward=(f"{re.escape(forward[1])}", forward[0]),
+        )
+
+
+class StrRepl(StrSub):
+    """
+    Replaces an entire string with another.
+    """
+
+    def __init__(self, replacee: str, replacement: str, *, reversible: bool = True):
+        """
+        Construct a reversible replacement.
+
+        :param replacee:
+            The full string to be replaced.
+        :param replacement:
+            The replacement string.
+        """
+        super().__init__(
+            forward=(f"^{re.escape(replacee)}$", replacement),
+            backward=(f"^{re.escape(replacement)}$", replacee) if reversible else None,
+        )
+
+
+class StrLStrip(StrSub):
+    """
+    Strips a prefix from a given string.
+    """
+
+    def __init__(self, prefix: str, *, reversible: bool = True):
+        """
+        Construct a reversible left strip.
+
+        :param prefix:
+            Prefix to be stripped.
+        """
+        super().__init__(
+            forward=(f"^{re.escape(prefix)}", ""),
+            backward=(r"^(.)", f"{prefix}\\1") if reversible else None,
+        )

--- a/curated_transformers/util/string.py
+++ b/curated_transformers/util/string.py
@@ -75,25 +75,28 @@ class StringTransformations:
         return StringSubRegEx(forward, backward)
 
     @staticmethod
-    def regex_sub_invertible(forward: Tuple[str, str]) -> StringTransform:
+    def sub(
+        substring: str, replacement: str, *, reversible: bool = True
+    ) -> StringTransform:
         """
-        Factory method to construct a string substitution transform
-        using regular expressions whose backward transformation can
-        be automatically derived from the forward transformation.
+        Factory method to construct a string substitution transform.
 
-        :param forward:
-            Tuple where the first string is string to match
-            and the second the replacement, neither of which
-            can contain RegEx meta-characters.
+        :param substring:
+            The substring to be replaced.
+        :param replacement:
+            The replacement string.
+        :param reversible:
+            If the reverse transformation is to
+            be performed.
         """
-        return StringSubInvertible(forward)
+        return StringSub(substring, replacement, reversible=reversible)
 
     @staticmethod
     def replace(
         replacee: str, replacement: str, *, reversible: bool = True
     ) -> StringTransform:
         """
-        Factory method to construct a string replacement transform.
+        Factory method to construct a full string replacement transform.
 
         :param replacee:
             The full string to be replaced.
@@ -156,25 +159,32 @@ class StringSubRegEx(StringTransform):
         return re.sub(self.backward[0], self.backward[1], string)
 
 
-class StringSubInvertible(StringSubRegEx):
+class StringSub(StringTransform):
     """
-    A substitution whose backward transformation can be
-    automatically derived from the forward transformation.
+    Substitute a substring with another string.
     """
 
-    def __init__(self, forward: Tuple[str, str]):
+    def __init__(self, substring: str, replacement: str, *, reversible: bool = True):
         """
-        Construct a reversible (and invertible) substitution.
+        Construct a reversible substitution.
 
-        :param forward:
-            Tuple where the first string is string to match
-            and the second the replacement, neither of which
-            can contain RegEx meta-characters.
+        :param substring:
+            The substring to be replaced.
+        :param replacement:
+            The replacement string.
+        :param reversible:
+            If the reverse transformation is to
+            be performed.
         """
-        super().__init__(
-            forward=(f"{re.escape(forward[0])}", forward[1]),
-            backward=(f"{re.escape(forward[1])}", forward[0]),
-        )
+        super().__init__(reversible)
+        self.substring = substring
+        self.replacement = replacement
+
+    def _apply(self, string: str) -> str:
+        return string.replace(self.substring, self.replacement)
+
+    def _revert(self, string: str) -> str:
+        return string.replace(self.replacement, self.substring)
 
 
 class StringReplace(StringTransform):

--- a/curated_transformers/util/string.py
+++ b/curated_transformers/util/string.py
@@ -147,6 +147,8 @@ class StringRemovePrefix(StringSubRegEx):
         :param prefix:
             Prefix to be stripped.
         """
+        # TODO: Should be replaced with `removeprefix` once
+        # Python 3.9 is the minimum requirement.
         super().__init__(
             forward=(f"^{re.escape(prefix)}", ""),
             backward=(r"^(.)", f"{prefix}\\1") if reversible else None,

--- a/curated_transformers/util/string.py
+++ b/curated_transformers/util/string.py
@@ -46,9 +46,10 @@ class StringTransform(ABC):
             return string
 
 
-class StrSub(StringTransform):
+class StringSubRegEx(StringTransform):
     """
-    Substitute a substring with another string.
+    Substitute a substring with another string using
+    regular expressions.
     """
 
     def __init__(self, forward: Tuple[str, str], backward: Optional[Tuple[str, str]]):
@@ -81,7 +82,7 @@ class StrSub(StringTransform):
         return re.sub(self.backward[0], self.backward[1], string)
 
 
-class StrSubInv(StrSub):
+class StringSubInvertible(StringSubRegEx):
     """
     A substitution whose backward transformation can be
     automatically derived from the forward transformation.
@@ -102,7 +103,7 @@ class StrSubInv(StrSub):
         )
 
 
-class StrRepl(StrSub):
+class StringReplace(StringTransform):
     """
     Replaces an entire string with another.
     """
@@ -116,13 +117,7 @@ class StrRepl(StrSub):
         :param replacement:
             The replacement string.
         """
-        super().__init__(
-            forward=(f"^{re.escape(replacee)}$", replacement),
-            backward=(f"^{re.escape(replacement)}$", replacee) if reversible else None,
-        )
-
-
-class StrLStrip(StrSub):
+class StringRemovePrefix(StringSubRegEx):
     """
     Strips a prefix from a given string.
     """

--- a/curated_transformers/util/string.py
+++ b/curated_transformers/util/string.py
@@ -118,6 +118,23 @@ class StringReplace(StringTransform):
         :param replacement:
             The replacement string.
         """
+        super().__init__(reversible)
+        self.replacee = replacee
+        self.replacement = replacement
+
+    def _apply(self, string: str) -> str:
+        if string == self.replacee:
+            return self.replacement
+        else:
+            return string
+
+    def _revert(self, string: str) -> str:
+        if string == self.replacement:
+            return self.replacee
+        else:
+            return string
+
+
 class StringRemovePrefix(StringSubRegEx):
     """
     Strips a prefix from a given string.

--- a/curated_transformers/util/string.py
+++ b/curated_transformers/util/string.py
@@ -135,7 +135,7 @@ class StringReplace(StringTransform):
             return string
 
 
-class StringRemovePrefix(StringSubRegEx):
+class StringRemovePrefix(StringTransform):
     """
     Strips a prefix from a given string.
     """
@@ -147,9 +147,14 @@ class StringRemovePrefix(StringSubRegEx):
         :param prefix:
             Prefix to be stripped.
         """
+
+        super().__init__(reversible)
+        self.prefix = prefix
+
+    def _apply(self, string: str) -> str:
         # TODO: Should be replaced with `removeprefix` once
         # Python 3.9 is the minimum requirement.
-        super().__init__(
-            forward=(f"^{re.escape(prefix)}", ""),
-            backward=(r"^(.)", f"{prefix}\\1") if reversible else None,
-        )
+        return re.sub(f"^{re.escape(self.prefix)}", "", string)
+
+    def _revert(self, string: str) -> str:
+        return f"{self.prefix}{string}"

--- a/docs/source/api-compat.rst
+++ b/docs/source/api-compat.rst
@@ -110,3 +110,5 @@ Version 1 to 2
 * The factory methods of :py:class:`~curated_transformers.layers.AttentionHeads`
   add a new ``qkv_split`` argument which is mandatory in future versions.
 * The ``FromHFHub`` mixins will be renamed to ``FromHF``.
+* The ``convert_hf_state_dict`` method in ``FromHFHub`` will be removed 
+  in favour of ``state_dict_from_hf``.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
This is the first of a series of PRs that aim to implement serialization support by way of producing serialized models that are usable with the Hugging Face `transformers` library.

The main addition of this PR is a selection of string transformation classes (in `util.string`) that are used to perform reversible transformations of parameter names in PyTorch state dicts. The existing ad-hoc transformation code has been rewritten with the above classes, and the Curated-to-HF conversions are tested for all supported models.

Additionally, the module structure has been changed in the following manner: The `models.hf_hub` module has been split into sub-modules `models.hf_hub.conversion` and `models.hf_hub.mixin`. The `FromHFHub` mixin is re-exported in `models.hf_hub` to preserve backward compatibility.

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
