### PR TITLE
Register models using `catalogue`

### DIFF
--- a/curated_transformers/__init__.py
+++ b/curated_transformers/__init__.py
@@ -1,0 +1,19 @@
+import catalogue
+from catalogue import Registry
+
+
+class registry(object):
+    """
+    Registry for models. These registries are used by auto classes to
+    discover the available models.
+    """
+
+    causal_lms: Registry = catalogue.create(
+        "curated_transformers", "causal_lms", entry_points=True
+    )
+    decoders: Registry = catalogue.create(
+        "curated_transformers", "decoders", entry_points=True
+    )
+    encoders: Registry = catalogue.create(
+        "curated_transformers", "encoders", entry_points=True
+    )

--- a/curated_transformers/models/albert/encoder.py
+++ b/curated_transformers/models/albert/encoder.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional, Type, TypeVar
+from typing import Any, Mapping, Optional, Tuple, Type, TypeVar
 
 import torch
 from torch import Tensor
@@ -98,6 +98,10 @@ class ALBERTEncoder(EncoderModule[ALBERTConfig], FromHFHub):
                 layer_outputs.append(layer_output)
 
         return ModelOutput(all_outputs=[embeddings, *layer_outputs])
+
+    @classmethod
+    def hf_model_types(cls: Type[Self]) -> Tuple[str, ...]:
+        return ("albert",)
 
     @classmethod
     def state_dict_from_hf(

--- a/curated_transformers/models/auto_model.py
+++ b/curated_transformers/models/auto_model.py
@@ -39,7 +39,7 @@ class AutoModel(ABC, Generic[ModelT]):
         for entrypoint, module_cls in cls._registry.get_entry_points().items():
             if not issubclass(module_cls, FromHFHub):
                 warnings.warn(
-                    f"Entry point {entrypoint} cannot load from Huggingface Hub "
+                    f"Entry point `{entrypoint}` cannot load from Hugging Face Hub "
                     "since the FromHFHub mixin is not implemented"
                 )
                 continue

--- a/curated_transformers/models/auto_model.py
+++ b/curated_transformers/models/auto_model.py
@@ -1,27 +1,21 @@
+import warnings
 from abc import ABC, abstractmethod
-from typing import Dict, Generic, Optional, Type, TypeVar
+from typing import Generic, Optional, Type, TypeVar
 
 import torch
+from catalogue import Registry
 from fsspec import AbstractFileSystem
+
+from curated_transformers import registry
 
 from ..layers.cache import KeyValueCache
 from ..quantization.bnb.config import BitsAndBytesConfig
 from ..repository.fsspec import FsspecArgs, FsspecRepository
 from ..repository.hf_hub import HfHubRepository
 from ..repository.repository import ModelRepository, Repository
-from .albert import ALBERTEncoder
-from .bert import BERTEncoder
-from .camembert import CamemBERTEncoder
 from .config import TransformerConfig
-from .falcon import FalconCausalLM, FalconDecoder
-from .gpt_neox import GPTNeoXCausalLM, GPTNeoXDecoder
 from .hf_hub import FromHFHub
-from .llama import LlamaCausalLM, LlamaDecoder
 from .module import CausalLMModule, DecoderModule, EncoderModule
-from .mpt.causal_lm import MPTCausalLM
-from .mpt.decoder import MPTDecoder
-from .roberta import RoBERTaEncoder
-from .xlm_roberta import XLMREncoder
 
 ModelT = TypeVar("ModelT")
 
@@ -32,7 +26,7 @@ class AutoModel(ABC, Generic[ModelT]):
     Face Model Hub.
     """
 
-    _hf_model_type_to_curated: Dict[str, Type[FromHFHub]] = {}
+    _registry: Registry
 
     @classmethod
     def _resolve_model_cls(
@@ -40,14 +34,25 @@ class AutoModel(ABC, Generic[ModelT]):
         repo: ModelRepository,
     ) -> Type[FromHFHub]:
         model_type = repo.model_type()
-        module_cls = cls._hf_model_type_to_curated.get(model_type)
-        if module_cls is None:
-            raise ValueError(
-                f"Unsupported model type `{model_type}` for {cls.__name__}. "
-                f"Supported model types: {tuple(cls._hf_model_type_to_curated.keys())}"
-            )
-        assert issubclass(module_cls, FromHFHub)
-        return module_cls
+
+        supported_model_types = set()
+        for entrypoint, module_cls in cls._registry.get_entry_points().items():
+            if not issubclass(module_cls, FromHFHub):
+                warnings.warn(
+                    f"Entry point {entrypoint} cannot load from Huggingface Hub "
+                    "since the FromHFHub mixin is not implemented"
+                )
+                continue
+
+            module_model_types = module_cls.hf_model_types()
+            if model_type in module_model_types:
+                return module_cls
+            supported_model_types.update(module_model_types)
+
+        raise ValueError(
+            f"Unsupported model type `{model_type}` for {cls.__name__}. "
+            f"Supported model types: {', '.join(sorted(supported_model_types))}"
+        )
 
     @classmethod
     def _instantiate_model(
@@ -182,13 +187,7 @@ class AutoEncoder(AutoModel[EncoderModule[TransformerConfig]]):
     Encoder model loaded from the Hugging Face Model Hub.
     """
 
-    _hf_model_type_to_curated: Dict[str, Type[FromHFHub]] = {
-        "bert": BERTEncoder,
-        "albert": ALBERTEncoder,
-        "camembert": CamemBERTEncoder,
-        "roberta": RoBERTaEncoder,
-        "xlm-roberta": XLMREncoder,
-    }
+    _registry: Registry = registry.encoders
 
     @classmethod
     def from_repo(
@@ -208,14 +207,7 @@ class AutoDecoder(AutoModel[DecoderModule[TransformerConfig, KeyValueCache]]):
     Decoder module loaded from the Hugging Face Model Hub.
     """
 
-    _hf_model_type_to_curated: Dict[str, Type[FromHFHub]] = {
-        "falcon": FalconDecoder,
-        "gpt_neox": GPTNeoXDecoder,
-        "llama": LlamaDecoder,
-        "mpt": MPTDecoder,
-        "RefinedWeb": FalconDecoder,
-        "RefinedWebModel": FalconDecoder,
-    }
+    _registry = registry.decoders
 
     @classmethod
     def from_repo(
@@ -235,14 +227,7 @@ class AutoCausalLM(AutoModel[CausalLMModule[TransformerConfig, KeyValueCache]]):
     Causal LM model loaded from the Hugging Face Model Hub.
     """
 
-    _hf_model_type_to_curated: Dict[str, Type[FromHFHub]] = {
-        "falcon": FalconCausalLM,
-        "gpt_neox": GPTNeoXCausalLM,
-        "llama": LlamaCausalLM,
-        "mpt": MPTCausalLM,
-        "RefinedWeb": FalconCausalLM,
-        "RefinedWebModel": FalconCausalLM,
-    }
+    _registry: Registry = registry.causal_lms
 
     @classmethod
     def from_repo(

--- a/curated_transformers/models/bert/encoder.py
+++ b/curated_transformers/models/bert/encoder.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Any, Mapping, Optional, Type, TypeVar
+from typing import Any, Mapping, Optional, Tuple, Type, TypeVar
 
 import torch
 from torch import Tensor
@@ -104,6 +104,10 @@ class BERTEncoder(TransformerEncoder[BERTConfig], FromHFHub):
                 for _ in range(config.layer.n_hidden_layers)
             ]
         )
+
+    @classmethod
+    def hf_model_types(cls: Type[Self]) -> Tuple[str, ...]:
+        return ("bert",)
 
     @classmethod
     def state_dict_from_hf(

--- a/curated_transformers/models/camembert/encoder.py
+++ b/curated_transformers/models/camembert/encoder.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 import torch
 
@@ -25,3 +25,7 @@ class CamemBERTEncoder(RoBERTaEncoder):
             The encoder.
         """
         super().__init__(config, device=device)
+
+    @classmethod
+    def hf_model_types(cls) -> Tuple[str, ...]:
+        return ("camembert",)

--- a/curated_transformers/models/falcon/causal_lm.py
+++ b/curated_transformers/models/falcon/causal_lm.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional, Set, Type, TypeVar
+from typing import Any, Mapping, Optional, Set, Tuple, Type, TypeVar
 
 import torch
 from torch import Tensor
@@ -51,6 +51,10 @@ class FalconCausalLM(TransformerCausalLM[FalconConfig], FromHFHub, Quantizable):
         cls: Type[Self], params: Mapping[str, Tensor]
     ) -> Mapping[str, Tensor]:
         return state_dict_from_hf(params, CAUSAL_LM_HF_PARAM_KEY_TRANSFORMS)
+
+    @classmethod
+    def hf_model_types(cls: Type[Self]) -> Tuple[str, ...]:
+        return ("falcon", "RefinedWeb", "RefinedWebModel")
 
     @classmethod
     def state_dict_to_hf(

--- a/curated_transformers/models/falcon/decoder.py
+++ b/curated_transformers/models/falcon/decoder.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Any, Mapping, Optional, Type, TypeVar
+from typing import Any, Mapping, Optional, Tuple, Type, TypeVar
 
 import torch
 from torch import Tensor
@@ -85,6 +85,10 @@ class FalconDecoder(TransformerDecoder[FalconConfig], FromHFHub):
             config.layer.layer_norm_eps,
             device=device,
         )
+
+    @classmethod
+    def hf_model_types(cls: Type[Self]) -> Tuple[str, ...]:
+        return ("falcon", "RefinedWeb", "RefinedWebModel")
 
     @classmethod
     def state_dict_from_hf(

--- a/curated_transformers/models/gpt_neox/causal_lm.py
+++ b/curated_transformers/models/gpt_neox/causal_lm.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional, Set, Type, TypeVar
+from typing import Any, Mapping, Optional, Set, Tuple, Type, TypeVar
 
 import torch
 from torch import Tensor
@@ -45,6 +45,10 @@ class GPTNeoXCausalLM(TransformerCausalLM[GPTNeoXConfig], FromHFHub, Quantizable
             bias=False,
             device=device,
         )
+
+    @classmethod
+    def hf_model_types(cls: Type[Self]) -> Tuple[str, ...]:
+        return ("gpt_neox",)
 
     @classmethod
     def state_dict_from_hf(

--- a/curated_transformers/models/gpt_neox/decoder.py
+++ b/curated_transformers/models/gpt_neox/decoder.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Any, Mapping, Optional, Type, TypeVar
+from typing import Any, Mapping, Optional, Tuple, Type, TypeVar
 
 import torch
 from torch import Tensor
@@ -113,6 +113,10 @@ class GPTNeoXDecoder(TransformerDecoder[GPTNeoXConfig], FromHFHub):
         self.output_layer_norm = LayerNorm(
             hidden_width, config.layer.layer_norm_eps, device=device
         )
+
+    @classmethod
+    def hf_model_types(cls: Type[Self]) -> Tuple[str, ...]:
+        return ("gpt_neox",)
 
     @classmethod
     def state_dict_from_hf(

--- a/curated_transformers/models/hf_hub/mixin.py
+++ b/curated_transformers/models/hf_hub/mixin.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Mapping, Optional, Type, TypeVar
+from typing import Any, Mapping, Optional, Tuple, Type, TypeVar
 
 import torch
 from fsspec import AbstractFileSystem
@@ -167,6 +167,17 @@ class FromHFHub(ABC):
             device=device,
             quantization_config=quantization_config,
         )
+
+    @classmethod
+    @abstractmethod
+    def hf_model_types(cls: Type[Self]) -> Tuple[str, ...]:
+        """
+        Get the Hugging Face model types supported by this model.
+
+        :returns:
+            The supported model types.
+        """
+        ...
 
     @abstractmethod
     def to(

--- a/curated_transformers/models/llama/causal_lm.py
+++ b/curated_transformers/models/llama/causal_lm.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional, Set, Type, TypeVar
+from typing import Any, Mapping, Optional, Set, Tuple, Type, TypeVar
 
 import torch
 from torch import Tensor
@@ -46,6 +46,10 @@ class LlamaCausalLM(TransformerCausalLM[LlamaConfig], FromHFHub, Quantizable):
             bias=False,
             device=device,
         )
+
+    @classmethod
+    def hf_model_types(cls: Type[Self]) -> Tuple[str, ...]:
+        return ("llama",)
 
     @classmethod
     def state_dict_from_hf(

--- a/curated_transformers/models/llama/decoder.py
+++ b/curated_transformers/models/llama/decoder.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Any, Mapping, Optional, Type, TypeVar
+from typing import Any, Mapping, Optional, Tuple, Type, TypeVar
 
 import torch
 from torch import Tensor
@@ -119,6 +119,10 @@ class LlamaDecoder(TransformerDecoder[LlamaConfig], FromHFHub):
         self.output_layer_norm = RMSNorm(
             hidden_width, eps=config.layer.layer_norm_eps, device=device
         )
+
+    @classmethod
+    def hf_model_types(cls: Type[Self]) -> Tuple[str, ...]:
+        return ("llama",)
 
     @classmethod
     def state_dict_from_hf(

--- a/curated_transformers/models/mpt/causal_lm.py
+++ b/curated_transformers/models/mpt/causal_lm.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Mapping, Optional, Set, Type, TypeVar
+from typing import Any, List, Mapping, Optional, Set, Tuple, Type, TypeVar
 
 import torch
 import torch.nn.functional as F
@@ -83,6 +83,10 @@ class MPTCausalLM(TransformerCausalLM[MPTConfig], FromHFHub, Quantizable):
             cache=decoder_output.cache,
             logits=logits,
         )
+
+    @classmethod
+    def hf_model_types(cls: Type[Self]) -> Tuple[str, ...]:
+        return ("mpt",)
 
     @classmethod
     def state_dict_from_hf(

--- a/curated_transformers/models/mpt/decoder.py
+++ b/curated_transformers/models/mpt/decoder.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional, Type, TypeVar
+from typing import Any, Mapping, Optional, Tuple, Type, TypeVar
 
 import torch
 from torch import Tensor
@@ -119,6 +119,10 @@ class MPTDecoder(TransformerDecoder[MPTConfig], FromHFHub):
         )
 
         self.output_layer_norm = layer_norm()
+
+    @classmethod
+    def hf_model_types(cls: Type[Self]) -> Tuple[str, ...]:
+        return ("mpt",)
 
     @classmethod
     def state_dict_from_hf(

--- a/curated_transformers/models/roberta/encoder.py
+++ b/curated_transformers/models/roberta/encoder.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Any, Mapping, Optional, Type, TypeVar
+from typing import Any, Mapping, Optional, Tuple, Type, TypeVar
 
 import torch
 from torch import Tensor
@@ -104,6 +104,10 @@ class RoBERTaEncoder(TransformerEncoder[RoBERTaConfig], FromHFHub):
                 for _ in range(config.layer.n_hidden_layers)
             ]
         )
+
+    @classmethod
+    def hf_model_types(cls: Type[Self]) -> Tuple[str, ...]:
+        return ("roberta",)
 
     @classmethod
     def state_dict_from_hf(

--- a/curated_transformers/models/xlm_roberta/encoder.py
+++ b/curated_transformers/models/xlm_roberta/encoder.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 import torch
 
@@ -25,3 +25,7 @@ class XLMREncoder(RoBERTaEncoder):
             The encoder.
         """
         super().__init__(config, device=device)
+
+    @classmethod
+    def hf_model_types(cls) -> Tuple[str, ...]:
+        return ("xlm-roberta",)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,6 +9,7 @@ API
    decoders
    causal-lm
    generation
+   registries
    repositories
    tokenizers
    quantization

--- a/docs/source/registries.rst
+++ b/docs/source/registries.rst
@@ -1,0 +1,24 @@
+Registries
+==========
+
+All models in Curated Transformers are added to a registry. Each auto class uses
+a registry to query which models are available. This mechanism allows
+third-party models to hook into the auto classes. This makes it possible to use
+construction methods such as ``AutoModel.from_hf_hub`` with third-party models.
+
+Third-party packages can register models in the ``options.entry_points`` section
+of ``setup.cfg``. For example, if the ``models`` module of the
+``extra-transformers`` package contains the ``FooCausalLM``, ``BarDecoder``, and
+``BazEncoder`` classes, they can be registered in ``setup.cfg`` as follows:
+
+.. code-block:: ini
+
+   [options.entry_points]
+   curated_transformers_causal_lms =
+       extra-transformers.FooCausalLM = extra_transformers.models:FooCausalLM
+
+   curated_transformers_decoders =
+       extra-transformers.BarDecoder = extra_transformers.models:BarDecoder
+
+   curated_transformers_encoders =
+       extra-transformers.BazEncoder = extra_transformers.models:BazEncoder

--- a/docs/source/registries.rst
+++ b/docs/source/registries.rst
@@ -4,7 +4,9 @@ Registries
 All models in Curated Transformers are added to a registry. Each auto class uses
 a registry to query which models are available. This mechanism allows
 third-party models to hook into the auto classes. This makes it possible to use
-construction methods such as ``AutoModel.from_hf_hub`` with third-party models.
+construction methods such as
+:py:class:`~curated_transformers.models.AutoEncoder.from_hf_hub` with third-party
+models.
 
 Third-party packages can register models in the ``options.entry_points`` section
 of ``setup.cfg``. For example, if the ``models`` module of the

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+catalogue>=2.0.4,<2.1.0
 curated-tokenizers>=0.9.1,<1.0.0
 huggingface-hub>=0.14
 tokenizers>=0.13.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ zip_safe = true
 include_package_data = true
 python_requires = >=3.8
 install_requires =
+    catalogue>=2.0.4,<2.1.0
     curated-tokenizers>=0.9.1,<1.0.0
     huggingface-hub>=0.14
     tokenizers>=0.13.3
@@ -24,8 +25,28 @@ quantization =
     bitsandbytes>=0.40
     # bitsandbytes has a dependency on scipy but doesn't 
     # list it as one for pip installs. So, we'll pull that
-    # in too (until its rectified upstream).
+    # in too (until it's rectified upstream).
     scipy>=1.11
+
+[options.entry_points]
+curated_transformers_causal_lms =
+    curated-transformers.LlamaCausalLM = curated_transformers.models:LlamaCausalLM
+    curated-transformers.FalconCausalLM = curated_transformers.models:FalconCausalLM
+    curated-transformers.GPTNeoXCausalLM = curated_transformers.models:GPTNeoXCausalLM
+    curated-transformers.MPTCausalLM = curated_transformers.models:MPTCausalLM
+
+curated_transformers_decoders =
+    curated-transformers.LlamaDecoder = curated_transformers.models:LlamaDecoder
+    curated-transformers.FalconDecoder = curated_transformers.models:FalconDecoder
+    curated-transformers.GPTNeoXDecoder = curated_transformers.models:GPTNeoXDecoder
+    curated-transformers.MPTDecoder = curated_transformers.models:MPTDecoder
+
+curated_transformers_encoders =
+    curated-transformers.ALBERTEncoder = curated_transformers.models:ALBERTEncoder
+    curated-transformers.BERTEncoder = curated_transformers.models:BERTEncoder
+    curated-transformers.CamemBERTEncoder = curated_transformers.models:CamemBERTEncoder
+    curated-transformers.RoBERTaEncoder = curated_transformers.models:RoBERTaEncoder
+    curated-transformers.XLMREncoder = curated_transformers.models:XLMREncoder
 
 [bdist_wheel]
 universal = true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->


So far we have hardcoded the available encoders/decoders/causal LMs in the auto classes. This has the downside that the auto classes only work with models that are provided by Curated Transformers.

This change adds registries for encoders/decoders/causal LMs. The auto classes query the relevant registry and check which registered model supports the downloaded model (through the `hf_model_types` method of the `FromHFHub` mixin). This makes it possible to register external models with Curated Transformers, so that they can also be used with the auto classes.

Adding registries for tokenizers and generators is deferred to future PRs.

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
