### PR TITLE
Add support for file write/upload operations with `HfHubRepository`

### DIFF
--- a/curated_transformers/repository/__init__.py
+++ b/curated_transformers/repository/__init__.py
@@ -1,16 +1,19 @@
 from .file import LocalFile, RepositoryFile
 from .fsspec import FsspecArgs, FsspecFile, FsspecRepository
-from .hf_hub import HfHubRepository
+from .hf_hub import HfHubFile, HfHubRepository
 from .repository import ModelRepository, Repository, TokenizerRepository
+from .transaction import TransactionContext
 
 __all__ = [
     "FsspecArgs",
     "FsspecFile",
     "FsspecRepository",
+    "HfHubFile",
     "HfHubRepository",
     "LocalFile",
     "ModelRepository",
     "Repository",
     "RepositoryFile",
     "TokenizerRepository",
+    "TransactionContext",
 ]

--- a/curated_transformers/repository/file.py
+++ b/curated_transformers/repository/file.py
@@ -1,3 +1,4 @@
+import os
 from abc import ABC, abstractmethod
 from typing import IO, Optional
 
@@ -22,6 +23,8 @@ class RepositoryFile(ABC):
             Encoding to use when the file is opened as text.
         :returns:
             An I/O stream.
+        :raises FileNotFoundError:
+            When the file cannot be found.
         :raises OSError:
             When the file cannot be opened.
         """
@@ -37,6 +40,14 @@ class RepositoryFile(ABC):
             The repository file. If the file is not available as a local
             path, the value of this property is ``None``. In these cases
             ``open`` can be used to get the file as a file-like object.
+        """
+        ...
+
+    @abstractmethod
+    def exists(self) -> bool:
+        """
+        Returns if the file exists. This can cause the file
+        to be cached locally.
         """
         ...
 
@@ -63,3 +74,6 @@ class LocalFile(RepositoryFile):
     @property
     def path(self) -> Optional[str]:
         return self._path
+
+    def exists(self) -> bool:
+        return os.path.isfile(self._path)

--- a/curated_transformers/repository/fsspec.py
+++ b/curated_transformers/repository/fsspec.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass
 from typing import IO, Any, Dict, Optional
 
@@ -145,6 +146,7 @@ class FsspecTransactionContext(TransactionContext):
         return self._repo
 
     def __enter__(self):
+        warnings.warn("Transaction support is currently not implemented for fsspec")
         return self
 
     def __exit__(self, exc_type, exc_value, exc_tb):

--- a/curated_transformers/repository/fsspec.py
+++ b/curated_transformers/repository/fsspec.py
@@ -4,6 +4,7 @@ from typing import IO, Any, Dict, Optional
 from fsspec import AbstractFileSystem
 
 from .repository import Repository, RepositoryFile
+from .transaction import TransactionContext
 
 
 @dataclass
@@ -55,18 +56,26 @@ class FsspecFile(RepositoryFile):
         self._fsspec_args = FsspecArgs() if fsspec_args is None else fsspec_args
 
     def open(self, mode: str = "rb", encoding: Optional[str] = None) -> IO:
+        if ("r" in mode or "+" in mode) and not self.exists():
+            raise FileNotFoundError(
+                f"Cannot find fsspec path {self._fs.unstrip_protocol(self._path)}"
+            )
+
         try:
             return self._fs.open(
                 self._path, mode=mode, encoding=encoding, **self._fsspec_args.kwargs
             )
         except Exception as e:
             raise OSError(
-                f"Cannot open fsspec path {self._fs.unstrip_protocol(self.path)}"
-            )
+                f"Cannot open fsspec path {self._fs.unstrip_protocol(self._path)}"
+            ) from e
 
     @property
     def path(self) -> Optional[str]:
         return None
+
+    def exists(self) -> bool:
+        return self._fs.exists(self._path, **self._fsspec_args.kwargs)
 
 
 class FsspecRepository(Repository):
@@ -97,8 +106,6 @@ class FsspecRepository(Repository):
 
     def file(self, path: str) -> RepositoryFile:
         full_path = f"{self.repo_path}/{path}"
-        if not self.fs.exists(full_path, **self.fsspec_args.kwargs):
-            raise FileNotFoundError(f"Cannot find file in repository: {path}")
         return FsspecFile(self.fs, full_path, self.fsspec_args)
 
     def pretty_path(self, path: Optional[str] = None) -> str:
@@ -106,6 +113,39 @@ class FsspecRepository(Repository):
             return self._protocol
         return f"{self._protocol}/{path}"
 
+    def transaction(self) -> TransactionContext:
+        return FsspecTransactionContext(self)
+
     @property
     def _protocol(self) -> str:
         return self.fs.unstrip_protocol(self.repo_path)
+
+
+class FsspecTransactionContext(TransactionContext):
+    """
+    `fsspec`_ transaction context manager.
+    TODO: Implement/currently a noop
+
+    .. _fsspec: https://filesystem-spec.readthedocs.io/en/latest/
+    """
+
+    def __init__(self, repo: FsspecRepository):
+        """
+        :param repo:
+            The parent repository.
+        """
+        super().__init__()
+        self._repo = repo
+
+    def open(self, path: str, mode: str, encoding: Optional[str] = None) -> IO:
+        return self._repo.file(path).open(mode=mode, encoding=encoding)
+
+    @property
+    def repo(self) -> Repository:
+        return self._repo
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        pass

--- a/curated_transformers/repository/hf_hub.py
+++ b/curated_transformers/repository/hf_hub.py
@@ -186,7 +186,7 @@ class HfHubTransactionContext(TransactionContext):
         commit_message = f"Uploading files:\n{filenames}"
 
         api = HfApi()
-        commit_info = api.create_commit(
+        _ = api.create_commit(
             repo_id=self._repo.name,
             revision=self._repo.revision,
             operations=commit_ops,

--- a/curated_transformers/repository/hf_hub.py
+++ b/curated_transformers/repository/hf_hub.py
@@ -1,7 +1,10 @@
+import os
 import warnings
-from typing import Optional
+from tempfile import NamedTemporaryFile
+from typing import IO, Any, AnyStr, Dict, Iterator, List, Optional
 
 import huggingface_hub
+from huggingface_hub import CommitOperationAdd, HfApi
 from huggingface_hub.utils import (
     EntryNotFoundError,
     RepositoryNotFoundError,
@@ -11,6 +14,84 @@ from requests import HTTPError, ReadTimeout  # type: ignore
 
 from ..repository.file import LocalFile, RepositoryFile
 from .repository import Repository
+from .transaction import TransactionContext
+
+
+class HfHubFile(RepositoryFile):
+    """
+    Wraps either a remote file on a Hugging Face Hub repository
+    or a local file in the Hugging Face cache.
+    """
+
+    def __init__(self, repo: "HfHubRepository", path: str):
+        """
+        Construct a Hugging Face file representation.
+
+        :param repo:
+            The parent repository.
+        :param path:
+            The path of the remote file in the repository.
+        """
+        super().__init__()
+
+        self._repo = repo
+        self._remote_path = path
+        self._cached_path = lookup_file_in_cache(repo.name, repo.revision, path)
+
+    def _validate_model_repo(self):
+        api = HfApi()
+        # This will raise RepositoryNotFoundError/RevisionNotFoundError upon failure.
+        _ = api.model_info(repo_id=self._repo.name, revision=self._repo.revision)
+
+    def _download_to_cache(self) -> LocalFile:
+        local_file = LocalFile(
+            hf_hub_download(
+                repo_id=self._repo.name,
+                filename=self._remote_path,
+                revision=self._repo.revision,
+            )
+        )
+        self._cached_path = local_file.path
+        return local_file
+
+    def open(self, mode: str = "rb", encoding: Optional[str] = None) -> IO:
+        try:
+            if "r" in mode:
+                # Attempt to download the file if we want to read from it.
+                local_file = self._download_to_cache()
+                return local_file.open(mode=mode, encoding=encoding)
+            elif "w" in mode:
+                # Return a proxy for the remote file.
+                self._validate_model_repo()
+                return UploadStagingBuffer(
+                    self._repo, self._remote_path, mode=mode, encoding=encoding
+                )
+            else:
+                raise OSError(
+                    f"Unsupported mode '{mode}' for opening Hugging Face Hub file"
+                )
+        except (
+            EntryNotFoundError,
+            RepositoryNotFoundError,
+            RevisionNotFoundError,
+        ) as e:
+            raise FileNotFoundError(
+                f"File not found: {self._repo.pretty_path(self._remote_path)}"
+            ) from e
+        except Exception as e:
+            raise OSError(
+                f"File could not be opened: {self._repo.pretty_path(self._remote_path)}"
+            ) from e
+
+    @property
+    def path(self) -> Optional[str]:
+        return self._cached_path
+
+    def exists(self) -> bool:
+        try:
+            return self._download_to_cache().exists()
+        except:
+            return False
 
 
 class HfHubRepository(Repository):
@@ -31,25 +112,200 @@ class HfHubRepository(Repository):
         self.revision = revision
 
     def file(self, path: str) -> RepositoryFile:
-        try:
-            return LocalFile(
-                path=hf_hub_download(
-                    repo_id=self.name, filename=path, revision=self.revision
-                )
-            )
-        except (
-            EntryNotFoundError,
-            RepositoryNotFoundError,
-            RevisionNotFoundError,
-        ) as e:
-            raise FileNotFoundError(f"File not found: {self.pretty_path(path)}") from e
-        except Exception as e:
-            raise OSError(f"File could not be opened: {self.pretty_path(path)}") from e
+        return HfHubFile(repo=self, path=path)
 
     def pretty_path(self, path: Optional[str] = None) -> str:
         if not path:
             return f"{self.name} (revision: {self.revision})"
         return f"{self.name}/{path} (revision: {self.revision})"
+
+    def transaction(self) -> TransactionContext:
+        return HfHubTransactionContext(self)
+
+
+class HfHubTransactionContext(TransactionContext):
+    """
+    Hugging Face Hub transaction context manager. Files opened
+    for writing are backed by temporary files on the host and
+    uploaded to the Hub when the transaction completes successfully.
+    """
+
+    def __init__(self, repo: HfHubRepository):
+        """
+        :param repo:
+            The parent repository.
+        """
+        super().__init__()
+        self._repo = repo
+        self._file_mappings: Dict[
+            str, IO
+        ] = {}  # Maps remote file paths to local temporary files
+
+    def open(self, path: str, mode: str, encoding: Optional[str] = None) -> IO:
+        if path in self._file_mappings:
+            raise OSError(f"Path '{path}' has already been opened")
+        elif "w" not in mode:
+            raise OSError(
+                f"File open mode '{mode}' is not supported inside a transaction - "
+                "files can only be opened for writing"
+            )
+
+        temp_file = NamedTemporaryFile(mode, encoding=encoding, delete=False)
+        self._file_mappings[path] = temp_file
+        return temp_file
+
+    @property
+    def repo(self) -> Repository:
+        return self._repo
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        if exc_type is None:
+            self._upload_temp_files()
+        self._release_temp_files()
+
+    def _upload_temp_files(self):
+        if len(self._file_mappings) == 0:
+            return
+
+        # Flush buffers.
+        for temp_file in self._file_mappings.values():
+            if not temp_file.closed:
+                temp_file.flush()
+
+        # Collate all files as a single commit.
+        commit_ops = [
+            CommitOperationAdd(path_in_repo=remote_path, path_or_fileobj=temp_file.name)
+            for remote_path, temp_file in self._file_mappings.items()
+        ]
+        filenames = "\n".join(self._file_mappings.keys())
+        commit_message = f"Uploading files:\n{filenames}"
+
+        api = HfApi()
+        commit_info = api.create_commit(
+            repo_id=self._repo.name,
+            revision=self._repo.revision,
+            operations=commit_ops,
+            commit_message=commit_message,
+            run_as_future=False,
+        )
+
+    def _release_temp_files(self):
+        for temp_file in self._file_mappings.values():
+            if not temp_file.closed:
+                temp_file.close()
+            os.remove(temp_file.name)
+
+
+class UploadStagingBuffer(IO):
+    """
+    Represents a local temporary file buffer that gets uploaded
+    to a repository when it's closed.
+    """
+
+    def __init__(
+        self,
+        repo: HfHubRepository,
+        remote_path: str,
+        *,
+        mode: str,
+        encoding: Optional[str],
+    ):
+        super().__init__()
+        self._repo = repo
+        self._remote_path = remote_path
+        self._temp_file = NamedTemporaryFile(mode, encoding=encoding, delete=False)
+
+    def _upload(self):
+        try:
+            api = HfApi()
+            result = api.upload_file(
+                path_in_repo=self._remote_path,
+                path_or_fileobj=self._temp_file,
+                repo_id=self._repo.name,
+                revision=self._repo.revision,
+                run_as_future=False,
+            )
+        except Exception as e:
+            raise OSError(
+                f"Failed to upload to remote file on Hugging Face Hub @ {self._repo.pretty_path(self._remote_path)}.\n"
+                f"Error: {e}"
+            )
+
+    # IO overrides follow.
+
+    def __iter__(self) -> Iterator[Any]:
+        return self._temp_file.__iter__()
+
+    def __next__(self) -> Any:
+        return self._temp_file.__next__()
+
+    @property
+    def mode(self) -> str:
+        return self._temp_file.mode
+
+    @property
+    def name(self) -> str:
+        return self._temp_file.name
+
+    def close(self) -> None:
+        return self._temp_file.close()
+
+    @property
+    def closed(self) -> bool:
+        return self._temp_file.closed
+
+    def fileno(self) -> int:
+        return self._temp_file.fileno()
+
+    def flush(self) -> None:
+        return self._temp_file.flush()
+
+    def isatty(self) -> bool:
+        return self._temp_file.isatty()
+
+    def read(self, n: int = -1) -> AnyStr:
+        return self._temp_file.read(n)
+
+    def readable(self) -> bool:
+        return self._temp_file.readable()
+
+    def readline(self, limit: int = -1) -> AnyStr:
+        return self._temp_file.readline(limit)
+
+    def readlines(self, hint: int = -1) -> List[AnyStr]:
+        return self._temp_file.readlines(hint)
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        return self._temp_file.seek(offset, whence)
+
+    def seekable(self) -> bool:
+        return self._temp_file.seekable()
+
+    def tell(self) -> int:
+        return self._temp_file.tell()
+
+    def truncate(self, size: int = None) -> int:  # type:ignore
+        return self._temp_file.truncate(size)
+
+    def writable(self) -> bool:
+        return self._temp_file.writable()
+
+    def write(self, s: AnyStr) -> int:
+        return self._temp_file.write(s)
+
+    def writelines(self, lines: List[AnyStr]) -> None:  # type:ignore
+        self._temp_file.writelines(lines)
+
+    def __enter__(self):
+        return self._temp_file
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        if exc_type is not None:
+            self._upload()
+        os.remove(self._temp_file.name)
 
 
 def hf_hub_download(repo_id: str, filename: str, revision: str) -> str:
@@ -79,10 +335,8 @@ def hf_hub_download(repo_id: str, filename: str, revision: str) -> str:
         )
     except (HTTPError, ReadTimeout) as e:
         # Attempt to check the cache.
-        resolved = huggingface_hub.try_to_load_from_cache(
-            repo_id=repo_id, filename=filename, revision=revision
-        )
-        if resolved is None or resolved is huggingface_hub._CACHED_NO_EXIST:
+        resolved = lookup_file_in_cache(repo_id, revision, filename)
+        if resolved is None:
             # Not found, rethrow.
             raise e
         else:
@@ -90,3 +344,27 @@ def hf_hub_download(repo_id: str, filename: str, revision: str) -> str:
                 f"Couldn't reach Hugging Face Hub; using cached artifact for '{repo_id}@{revision}:{filename}'"
             )
     return resolved
+
+
+def lookup_file_in_cache(repo_id: str, revision: str, filename: str) -> Optional[str]:
+    """
+    Look up the file in the local Hugging Face Hub cache.
+
+    :param repo_id:
+        Identifier of the source repository on Hugging Face Hub.
+    :param revision:
+        Source repository revision. Can either be a branch name
+        or a SHA hash of a commit.
+    :param filename:
+        Name of the file in the source repository to lookup in the cache.
+    :returns:
+        Local file path if found in cache, ``None`` otherwise.
+    """
+
+    resolved = huggingface_hub.try_to_load_from_cache(
+        repo_id=repo_id, filename=filename, revision=revision
+    )
+    if resolved is None or resolved is huggingface_hub._CACHED_NO_EXIST:
+        return None
+    else:
+        return resolved

--- a/curated_transformers/repository/hf_hub.py
+++ b/curated_transformers/repository/hf_hub.py
@@ -162,9 +162,11 @@ class HfHubTransactionContext(TransactionContext):
         return self
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        if exc_type is None:
-            self._upload_temp_files()
-        self._release_temp_files()
+        try:
+            if exc_type is None:
+                self._upload_temp_files()
+        finally:
+            self._release_temp_files()
 
     def _upload_temp_files(self):
         if len(self._file_mappings) == 0:
@@ -194,9 +196,11 @@ class HfHubTransactionContext(TransactionContext):
 
     def _release_temp_files(self):
         for temp_file in self._file_mappings.values():
-            if not temp_file.closed:
-                temp_file.close()
-            os.remove(temp_file.name)
+            try:
+                if not temp_file.closed:
+                    temp_file.close()
+            finally:
+                os.remove(temp_file.name)
 
 
 class UploadStagingBuffer(IO):
@@ -303,9 +307,11 @@ class UploadStagingBuffer(IO):
         return self._temp_file
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        if exc_type is not None:
-            self._upload()
-        os.remove(self._temp_file.name)
+        try:
+            if exc_type is not None:
+                self._upload()
+        finally:
+            os.remove(self._temp_file.name)
 
 
 def hf_hub_download(repo_id: str, filename: str, revision: str) -> str:

--- a/curated_transformers/repository/transaction.py
+++ b/curated_transformers/repository/transaction.py
@@ -1,0 +1,57 @@
+from abc import ABC, abstractmethod
+from typing import IO, TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from .repository import Repository
+
+
+class TransactionContext(ABC):
+    """
+    A context manager that represents an active transaction in
+    a repository.
+    """
+
+    @abstractmethod
+    def open(self, path: str, mode: str, encoding: Optional[str] = None) -> IO:
+        """
+        Opens a file as a part of a transaction. Changes to the
+        file are deferred until the transaction has completed
+        successfully.
+
+        :param path:
+            The path to the file on the parent repository.
+        :param mode:
+            Mode to open the file with (see Python ``open``).
+        :param encoding:
+            Encoding to use when the file is opened as text.
+        :returns:
+            An I/O stream.
+        :raises FileNotFoundError:
+            When the file cannot be found.
+        :raises OSError:
+            When the file cannot be opened.
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def repo(self) -> "Repository":
+        """
+        :returns:
+            The parent repository on which this transaction is performed.
+        """
+        ...
+
+    @abstractmethod
+    def __enter__(self):
+        """
+        Invoked when the context manager is entered.
+        """
+        ...
+
+    @abstractmethod
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        """
+        Invoked when the context manager exits.
+        """
+        ...

--- a/curated_transformers/tests/conftest.py
+++ b/curated_transformers/tests/conftest.py
@@ -39,7 +39,7 @@ def pytest_runtest_setup(item):
         return item.config.getoption(f"--{opt}", False)
 
     # Integration of boolean flags
-    for opt in ["slow", "upload-tests"]:
+    for opt in ["slow", "upload_tests"]:
         if opt in item.keywords and not getopt(opt.replace("_", "-")):
             pytest.skip(f"need --{opt} option to run")
 

--- a/curated_transformers/tests/conftest.py
+++ b/curated_transformers/tests/conftest.py
@@ -39,9 +39,9 @@ def pytest_runtest_setup(item):
         return item.config.getoption(f"--{opt}", False)
 
     # Integration of boolean flags
-    for opt in ["slow", "upload_tests"]:
+    for opt in ["upload_tests", "slow"]:
         if opt in item.keywords and not getopt(opt.replace("_", "-")):
-            pytest.skip(f"need --{opt} option to run")
+            pytest.skip(f"need --{opt.replace('_', '-')} option to run")
 
 
 @pytest.fixture

--- a/curated_transformers/tests/conftest.py
+++ b/curated_transformers/tests/conftest.py
@@ -9,11 +9,6 @@ GPU_TESTS_ENABLED = False
 
 def pytest_addoption(parser):
     try:
-        parser.addoption(
-            "--hf-head",
-            action="store_true",
-            help="include tests that require `transformers` development version",
-        )
         parser.addoption("--slow", action="store_true", help="include slow tests")
         parser.addoption(
             "--upload-tests",
@@ -28,10 +23,6 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: include slow tests")
-    config.addinivalue_line(
-        "markers",
-        "hf-head: include tests that require `transformers` development version",
-    )
     config.addinivalue_line(
         "markers", "upload-tests: tests that upload test artifacts to remote repos"
     )

--- a/curated_transformers/tests/conftest.py
+++ b/curated_transformers/tests/conftest.py
@@ -15,6 +15,11 @@ def pytest_addoption(parser):
             help="include tests that require `transformers` development version",
         )
         parser.addoption("--slow", action="store_true", help="include slow tests")
+        parser.addoption(
+            "--upload-tests",
+            action="store_true",
+            help="include tests that upload test artifacts to remote repos",
+        )
     # Options are already added, e.g. if conftest is copied in a build pipeline
     # and runs twice
     except ValueError:
@@ -26,6 +31,9 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers",
         "hf-head: include tests that require `transformers` development version",
+    )
+    config.addinivalue_line(
+        "markers", "upload-tests: tests that upload test artifacts to remote repos"
     )
 
 
@@ -40,7 +48,7 @@ def pytest_runtest_setup(item):
         return item.config.getoption(f"--{opt}", False)
 
     # Integration of boolean flags
-    for opt in ["slow"]:
+    for opt in ["slow", "upload-tests"]:
         if opt in item.keywords and not getopt(opt.replace("_", "-")):
             pytest.skip(f"need --{opt} option to run")
 

--- a/curated_transformers/tests/repository/test_hf_hub.py
+++ b/curated_transformers/tests/repository/test_hf_hub.py
@@ -1,11 +1,10 @@
 import pytest
-
 from curated_transformers.repository import HfHubRepository
 
 TEST_LINES = ["Line 1", "Line 2 🐍", "🤖" "\n\n", ""]
 
 
-@pytest.mark.slow
+@pytest.mark.upload_test
 def test_hf_hub_upload_txt():
     repo = HfHubRepository("explosion-testing/hf-upload-test")
 
@@ -20,7 +19,7 @@ def test_hf_hub_upload_txt():
         assert str_read == str_to_write
 
 
-@pytest.mark.slow
+@pytest.mark.upload_test
 def test_hf_hub_upload_binary():
     repo = HfHubRepository("explosion-testing/hf-upload-test")
 
@@ -35,7 +34,7 @@ def test_hf_hub_upload_binary():
         assert bytes_read == bytes_to_write
 
 
-@pytest.mark.slow
+@pytest.mark.upload_test
 def test_hf_hub_transactions():
     repo = HfHubRepository("explosion-testing/hf-upload-test")
 

--- a/curated_transformers/tests/repository/test_hf_hub.py
+++ b/curated_transformers/tests/repository/test_hf_hub.py
@@ -1,11 +1,10 @@
 import pytest
-
 from curated_transformers.repository import HfHubRepository
 
 TEST_LINES = ["Line 1", "Line 2 🐍", "🤖" "\n\n", ""]
 
 
-@pytest.mark.upload_test
+@pytest.mark.upload_tests
 def test_hf_hub_upload_txt():
     repo = HfHubRepository("explosion-testing/hf-upload-test")
 
@@ -20,7 +19,7 @@ def test_hf_hub_upload_txt():
         assert str_read == str_to_write
 
 
-@pytest.mark.upload_test
+@pytest.mark.upload_tests
 def test_hf_hub_upload_binary():
     repo = HfHubRepository("explosion-testing/hf-upload-test")
 
@@ -35,7 +34,7 @@ def test_hf_hub_upload_binary():
         assert bytes_read == bytes_to_write
 
 
-@pytest.mark.upload_test
+@pytest.mark.upload_tests
 def test_hf_hub_transactions():
     repo = HfHubRepository("explosion-testing/hf-upload-test")
 

--- a/curated_transformers/tests/repository/test_hf_hub.py
+++ b/curated_transformers/tests/repository/test_hf_hub.py
@@ -1,4 +1,5 @@
 import pytest
+
 from curated_transformers.repository import HfHubRepository
 
 TEST_LINES = ["Line 1", "Line 2 🐍", "🤖" "\n\n", ""]

--- a/curated_transformers/tests/repository/test_hf_hub.py
+++ b/curated_transformers/tests/repository/test_hf_hub.py
@@ -1,0 +1,82 @@
+import pytest
+
+from curated_transformers.repository import HfHubRepository
+
+TEST_LINES = ["Line 1", "Line 2 🐍", "🤖" "\n\n", ""]
+
+
+@pytest.mark.slow
+def test_hf_hub_upload_txt():
+    repo = HfHubRepository("explosion-testing/hf-upload-test")
+
+    write_file = repo.file("test.txt")
+    str_to_write = "\n".join(TEST_LINES)
+    with write_file.open(mode="w") as f:
+        f.write(str_to_write)
+
+    read_file = repo.file("test.txt")
+    with read_file.open(mode="r", encoding="utf-8") as f:
+        str_read = f.read()
+        assert str_read == str_to_write
+
+
+@pytest.mark.slow
+def test_hf_hub_upload_binary():
+    repo = HfHubRepository("explosion-testing/hf-upload-test")
+
+    write_file = repo.file("test.bin")
+    bytes_to_write = b"\x0D\x0E\x0A\x0D\x0B\x0E\x0E\x0F"
+    with write_file.open(mode="wb") as f:
+        f.write(bytes_to_write)
+
+    read_file = repo.file("test.bin")
+    with read_file.open(mode="rb") as f:
+        bytes_read = f.read()
+        assert bytes_read == bytes_to_write
+
+
+@pytest.mark.slow
+def test_hf_hub_transactions():
+    repo = HfHubRepository("explosion-testing/hf-upload-test")
+
+    with repo.transaction() as tx:
+        with tx.open("inner/test.txt", mode="w", encoding="utf-8") as f:
+            str_to_write = "\n".join(TEST_LINES)
+            f.write(str_to_write)
+        with tx.open("test.bin", mode="wb") as f:
+            bytes_to_write = b"\x0D\x0E\x0A\x0D\x0B\x0E\x0E\x0F"
+            f.write(bytes_to_write)
+
+    with repo.file("inner/test.txt").open(mode="r", encoding="utf-8") as f:
+        str_read = f.read()
+        assert str_read == str_to_write
+    with repo.file("test.bin").open(mode="rb") as f:
+        bytes_read = f.read()
+        assert bytes_read == bytes_to_write
+
+
+def test_hf_hub_failures():
+    repo = HfHubRepository("explosion-testing/hf-upload-test")
+    write_file = repo.file("nonexistent.bin")
+
+    assert write_file.path is None
+    with pytest.raises(FileNotFoundError):
+        with write_file.open("r") as f:
+            pass
+
+    with pytest.raises(OSError):
+        with write_file.open("a") as f:
+            pass
+
+    with pytest.raises(OSError, match="mode 'a' is not supported"):
+        with repo.transaction() as tx:
+            f = tx.open("test.txt", mode="a", encoding="utf-8")
+
+    with pytest.raises(OSError, match="mode 'rb' is not supported"):
+        with repo.transaction() as tx:
+            f = tx.open("test.bin", mode="rb")
+
+    with pytest.raises(OSError, match="already been opened"):
+        with repo.transaction() as tx:
+            f = tx.open("test.bin", mode="w")
+            f1 = tx.open("test.bin", mode="w")

--- a/curated_transformers/tokenizers/auto_tokenizer.py
+++ b/curated_transformers/tokenizers/auto_tokenizer.py
@@ -139,19 +139,16 @@ def _get_tokenizer_class_from_config(
 def _resolve_tokenizer_class(
     repo: TokenizerRepository,
 ) -> Type[FromHFHub]:
+    tokenizer_file = repo.tokenizer_json()
+    if tokenizer_file.exists():
+        return Tokenizer
+
     cls: Optional[Type[FromHFHub]] = None
     try:
-        repo.tokenizer_json()
-        cls = Tokenizer
+        tokenizer_config = repo.tokenizer_config()
+        cls = _get_tokenizer_class_from_config(tokenizer_config)
     except:
         pass
-
-    if cls is None:
-        try:
-            tokenizer_config = repo.tokenizer_config()
-            cls = _get_tokenizer_class_from_config(tokenizer_config)
-        except:
-            pass
 
     if cls is None:
         try:

--- a/curated_transformers/tokenizers/tokenizer.py
+++ b/curated_transformers/tokenizers/tokenizer.py
@@ -11,6 +11,7 @@ from tokenizers import Tokenizer as HFTokenizer
 from torch import Tensor
 
 from ..layers.attention import AttentionMask
+from ..repository.file import RepositoryFile
 from ..repository.fsspec import FsspecRepository
 from ..repository.hf_hub import HfHubRepository
 from ..repository.repository import Repository, TokenizerRepository
@@ -337,8 +338,16 @@ class Tokenizer(TokenizerBase, FromHFHub):
 
     @classmethod
     def from_repo(cls: Type[Self], repo: Repository) -> Self:
+        def validate_tokenizer_file(tokenizer_file: RepositoryFile):
+            # Since repository files are loaded lazily, we need to
+            # open them to check their validity. Will throw if invalid.
+            with tokenizer_file.open(mode="rb") as f:
+                pass
+
         repo = TokenizerRepository(repo)
         tokenizer_file = repo.tokenizer_json()
+        validate_tokenizer_file(tokenizer_file)
+
         if tokenizer_file.path is not None:
             hf_tokenizer = HFTokenizer.from_file(tokenizer_file.path)
         else:

--- a/docs/source/repositories.rst
+++ b/docs/source/repositories.rst
@@ -39,6 +39,10 @@ Base Classes
    :members:
    :show-inheritance:
 
+.. autoclass:: curated_transformers.repository.TransactionContext
+   :members:
+   :show-inheritance:   
+
 Repositories
 ------------
 
@@ -58,5 +62,9 @@ Repository Files
    :show-inheritance:
 
 .. autoclass:: curated_transformers.repository.LocalFile
+   :members:
+   :show-inheritance:
+
+.. autoclass:: curated_transformers.repository.HfHubFile
    :members:
    :show-inheritance:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
This PR introduces support for uploading files to Hugging Face Hub repositories through the current `RepositoryFile` API. In the case of `fsspec` repositories, we support implicit streaming of data using buffered IO. However, this is not possible with HF repositories due its usage of Git as a backing store. So, we need to allocate and write to files on the host's local storage device before uploading them as a Git commit operation to the remote repo.

The current implementation hides this detail by using a proxy to represent the remote file that we want to write to. The `HfHubFile` class wraps either a locally cached file from a HF repo or a temporary file on the local storage. The user can open and write to the latter like they would with any (`fsspec`) file - its contents will be uploaded to the repo as soon as the file handle is closed.

Furthermore, we also introduce the concept of transactional file writes using a context manager. This lets the user batch multiple file operations that get uploaded to the repo as a single commit. The `fsspec` implementation of transactions will be implemented in a follow-up PR.

Other changes:
- `Repository.file` returns a lazily-loaded file, i.e., its existence is only checked when the file is opened using the `open` method (or when the `exists` method is called).
- Fixed a bug in `FsspecRepository.open` that called `unstrip_protocol` on a `None` object.

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
