### PR TITLE
Ensure that parameters are leaf nodes when loading a model

### DIFF
--- a/curated_transformers/util/serde/load.py
+++ b/curated_transformers/util/serde/load.py
@@ -103,7 +103,7 @@ def default_tensor_to_parameter_converter(
     old_param = module._parameters[parameter_name]
     assert old_param is not None
     _validate_replacement(old_param, tensor, module_prefix)
-    return Parameter(tensor, requires_grad=old_param.requires_grad).to(device=device)  # type: ignore
+    return Parameter(tensor.to(device=device), requires_grad=old_param.requires_grad)  # type: ignore
 
 
 def _emplace_module_state_dict(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

There was a subtle bug where we populate models with parameters that are not leaf nodes because we called `to` on them for device placement.

This change fixes this issue and validates that all model parameters are leaf nodes in the model tests.

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
