### PR TITLE
Add support for loading parameters in-place

### DIFF
--- a/curated_transformers/models/albert/_hf.py
+++ b/curated_transformers/models/albert/_hf.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
+import torch
+
 from ...util.string import StringTransform, StringTransformations
 from ..hf_hub.conversion import (
     CommonHFKeys,
@@ -82,6 +84,7 @@ class HFConfigKeys:
 
 HF_CONFIG_KEYS: List[Tuple[HFConfigKey, Optional[HFConfigKeyDefault]]] = [
     (CommonHFKeys.ATTENTION_PROBS_DROPOUT_PROB, None),
+    (CommonHFKeys.DTYPE, HFConfigKeyDefault("float32")),
     (CommonHFKeys.EMBEDDING_SIZE, None),
     (CommonHFKeys.HIDDEN_DROPOUT_PROB, None),
     (CommonHFKeys.HIDDEN_SIZE, None),

--- a/curated_transformers/models/albert/config.py
+++ b/curated_transformers/models/albert/config.py
@@ -50,6 +50,7 @@ class ALBERTConfig(TransformerConfig):
     def __init__(
         self,
         *,
+        dtype: torch.dtype = torch.float32,
         embedding_width: int = 128,
         hidden_width: int = 768,
         n_layers_per_group: int = 1,
@@ -67,6 +68,8 @@ class ALBERTConfig(TransformerConfig):
         layer_norm_eps: float = 1e-12,
     ):
         """
+        :param dtype:
+            Data type to use for model parameters.
         :param embedding_width:
             Width of the embedding representations.
         :param hidden_width:
@@ -132,5 +135,5 @@ class ALBERTConfig(TransformerConfig):
             n_layers_per_group=n_layers_per_group,
             n_hidden_groups=n_hidden_groups,
         )
-        self.dtype = torch.float32
+        self.dtype = dtype
         self.model_max_length = model_max_length

--- a/curated_transformers/models/bert/_hf.py
+++ b/curated_transformers/models/bert/_hf.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
+import torch
+
 from ...util.string import StringTransform, StringTransformations
 from ..hf_hub.conversion import (
     CommonHFKeys,
@@ -63,6 +65,7 @@ HF_PARAM_KEY_TRANSFORMS: List[StringTransform] = [
 
 HF_CONFIG_KEYS: List[Tuple[HFConfigKey, Optional[HFConfigKeyDefault]]] = [
     (CommonHFKeys.ATTENTION_PROBS_DROPOUT_PROB, None),
+    (CommonHFKeys.DTYPE, HFConfigKeyDefault("float32")),
     (CommonHFKeys.HIDDEN_DROPOUT_PROB, None),
     (CommonHFKeys.HIDDEN_SIZE, None),
     (CommonHFKeys.HIDDEN_ACT, None),

--- a/curated_transformers/models/bert/config.py
+++ b/curated_transformers/models/bert/config.py
@@ -25,6 +25,7 @@ class BERTConfig(TransformerConfig):
     def __init__(
         self,
         *,
+        dtype: torch.dtype = torch.float32,
         embedding_width: int = 768,
         hidden_width: int = 768,
         intermediate_width: int = 3072,
@@ -40,6 +41,8 @@ class BERTConfig(TransformerConfig):
         layer_norm_eps: float = 1e-12,
     ):
         """
+        :param dtype:
+            Data type to use for model parameters.
         :param embedding_width:
             Width of the embedding representations.
         :param hidden_width:
@@ -99,5 +102,5 @@ class BERTConfig(TransformerConfig):
             layer_norm_eps=layer_norm_eps,
             dropout_prob=hidden_dropout_prob,
         )
-        self.dtype = torch.float32
+        self.dtype = dtype
         self.model_max_length = model_max_length

--- a/curated_transformers/models/falcon/_hf.py
+++ b/curated_transformers/models/falcon/_hf.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
+import torch
+
 from ...util.string import StringTransform, StringTransformations
 from ..hf_hub.conversion import (
     CommonCuratedToHFConverters,
@@ -148,6 +150,7 @@ class HFConfigKeys:
 HF_CONFIG_KEYS_REFINED_WEB_MODEL: List[
     Tuple[HFConfigKey, Optional[HFConfigKeyDefault]]
 ] = [
+    (CommonHFKeys.DTYPE, HFConfigKeyDefault("bfloat16")),
     (CommonHFKeys.HIDDEN_SIZE, None),
     (HFConfigKeys.N_HEAD, None),
     (HFConfigKeys.N_HEAD_KV, HFConfigKeyDefault(-1)),
@@ -165,6 +168,7 @@ HF_CONFIG_KEYS_REFINED_WEB_MODEL: List[
 # Corresponds to the mainline implementation for Falcon models
 # in the `transformers` library.
 HF_CONFIG_KEYS_FALCON: List[Tuple[HFConfigKey, Optional[HFConfigKeyDefault]]] = [
+    (CommonHFKeys.DTYPE, HFConfigKeyDefault("bfloat16")),
     (CommonHFKeys.HIDDEN_SIZE, None),
     (HFConfigKeys.NUM_ATTENTION_HEADS, None),
     (HFConfigKeys.NUM_HEAD_KV, HFConfigKeyDefault(-1)),

--- a/curated_transformers/models/falcon/config.py
+++ b/curated_transformers/models/falcon/config.py
@@ -27,6 +27,7 @@ class FalconConfig(TransformerConfig):
         self,
         *,
         attention_probs_dropout_prob: float = 0.0,
+        dtype: torch.dtype = torch.bfloat16,
         hidden_dropout_prob: float = 0.0,
         hidden_width: int = 2560,
         layer_norm_eps: float = 1e-5,
@@ -44,6 +45,8 @@ class FalconConfig(TransformerConfig):
         """
         :param attention_probs_dropout_prob:
             Dropout to apply after attention.
+        :param dtype:
+            Data type to use for model parameters.
         :param hidden_dropout_prob:
             Dropout to apply to the hidden and embedding layers.
         :param hidden_width:
@@ -109,5 +112,5 @@ class FalconConfig(TransformerConfig):
             layer_norm_eps=layer_norm_eps,
             n_hidden_layers=n_hidden_layers,
         )
-        self.dtype = torch.bfloat16
+        self.dtype = dtype
         self.new_decoder_architecture = new_decoder_architecture

--- a/curated_transformers/models/gpt_neox/_hf.py
+++ b/curated_transformers/models/gpt_neox/_hf.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
+import torch
+
 from ...util.string import StringTransform, StringTransformations
 from ..hf_hub.conversion import (
     CommonHFKeys,
@@ -62,6 +64,7 @@ class HFConfigKeys:
 
 
 HF_CONFIG_KEYS: List[Tuple[HFConfigKey, Optional[HFConfigKeyDefault]]] = [
+    (CommonHFKeys.DTYPE, HFConfigKeyDefault("float16")),
     (CommonHFKeys.HIDDEN_ACT, None),
     (CommonHFKeys.HIDDEN_SIZE, None),
     (CommonHFKeys.INTERMEDIATE_SIZE, None),

--- a/curated_transformers/models/gpt_neox/config.py
+++ b/curated_transformers/models/gpt_neox/config.py
@@ -26,6 +26,7 @@ class GPTNeoXConfig(TransformerConfig):
         *,
         attention_probs_dropout_prob: float = 0.0,
         activation: Activation = Activation.GELU,
+        dtype: torch.dtype = torch.float16,
         hidden_dropout_prob: float = 0.0,
         hidden_width: int = 2560,
         intermediate_width: int = 10240,
@@ -43,6 +44,8 @@ class GPTNeoXConfig(TransformerConfig):
             Dropout to apply after attention.
         :param activation:
             Activation used by the pointwise feed-forward layers.
+        :param dtype:
+            Data type to use for model parameters.
         :param hidden_dropout_prob:
             Dropout to apply to the hidden and embedding layers.
         :param hidden_width:
@@ -103,4 +106,4 @@ class GPTNeoXConfig(TransformerConfig):
             layer_norm_eps=layer_norm_eps,
             n_hidden_layers=n_hidden_layers,
         )
-        self.dtype = torch.float16
+        self.dtype = dtype

--- a/curated_transformers/models/llama/_hf.py
+++ b/curated_transformers/models/llama/_hf.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
+import torch
+
 from ...util.string import StringTransform, StringTransformations
 from ..hf_hub.conversion import (
     CommonCuratedToHFConverters,
@@ -77,6 +79,7 @@ class HFConfigKeys:
 
 
 HF_CONFIG_KEYS: List[Tuple[HFConfigKey, Optional[HFConfigKeyDefault]]] = [
+    (CommonHFKeys.DTYPE, HFConfigKeyDefault("float16")),
     (CommonHFKeys.HIDDEN_ACT, None),
     (CommonHFKeys.HIDDEN_SIZE, None),
     (CommonHFKeys.INTERMEDIATE_SIZE, None),

--- a/curated_transformers/models/llama/config.py
+++ b/curated_transformers/models/llama/config.py
@@ -27,6 +27,7 @@ class LlamaConfig(TransformerConfig):
         *,
         attention_probs_dropout_prob: float = 0.0,
         activation: Activation = Activation.GELU,
+        dtype: torch.dtype = torch.float16,
         hidden_dropout_prob: float = 0.0,
         hidden_width: int = 2560,
         intermediate_width: int = 10240,
@@ -43,6 +44,8 @@ class LlamaConfig(TransformerConfig):
             Dropout to apply after attention.
         :param activation:
             Activation used by the pointwise feed-forward layers.
+        :param dtype:
+            Data type to use for model parameters.
         :param hidden_dropout_prob:
             Dropout to apply to the hidden and embedding layers.
         :param hidden_width:
@@ -100,4 +103,4 @@ class LlamaConfig(TransformerConfig):
             layer_norm_eps=rms_norm_eps,
             n_hidden_layers=n_hidden_layers,
         )
-        self.dtype = torch.float16
+        self.dtype = dtype

--- a/curated_transformers/models/mpt/_hf.py
+++ b/curated_transformers/models/mpt/_hf.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
+import torch
+
 from ...util.string import StringTransform, StringTransformations
 from ..hf_hub.conversion import (
     CommonCuratedToHFConverters,
@@ -94,6 +96,7 @@ class HFConfigKeys:
 
 
 HF_CONFIG_KEYS: List[Tuple[HFConfigKey, Optional[HFConfigKeyDefault]]] = [
+    (CommonHFKeys.DTYPE, HFConfigKeyDefault("bfloat16")),
     (HFConfigKeys.D_MODEL, None),
     (HFConfigKeys.EXPANSION_RATIO, None),
     (HFConfigKeys.MAX_SEQ_LEN, None),

--- a/curated_transformers/models/mpt/config.py
+++ b/curated_transformers/models/mpt/config.py
@@ -25,6 +25,7 @@ class MPTConfig(TransformerConfig):
         *,
         attention_probs_dropout_prob: float = 0.0,
         activation: Activation = Activation.GELU,
+        dtype: torch.dtype = torch.bfloat16,
         hidden_dropout_prob: float = 0.0,
         hidden_width: int = 4096,
         intermediate_width_multiplier: int = 4,
@@ -40,6 +41,8 @@ class MPTConfig(TransformerConfig):
             Dropout to apply after attention.
         :param activation:
             Activation used by the pointwise feed-forward layers.
+        :param dtype:
+            Data type to use for model parameters.
         :param hidden_dropout_prob:
             Dropout to apply to the hidden and embedding layers.
         :param hidden_width:
@@ -94,5 +97,5 @@ class MPTConfig(TransformerConfig):
             layer_norm_eps=layer_norm_eps,
             n_hidden_layers=n_hidden_layers,
         )
-        self.dtype = torch.bfloat16
+        self.dtype = dtype
         self.model_max_length = model_max_length

--- a/curated_transformers/models/roberta/_hf.py
+++ b/curated_transformers/models/roberta/_hf.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
+import torch
+
 from ...util.string import StringTransform, StringTransformations
 from ..hf_hub.conversion import (
     CommonHFKeys,
@@ -73,6 +75,7 @@ class HFConfigKeys:
 
 HF_CONFIG_KEYS: List[Tuple[HFConfigKey, Optional[HFConfigKeyDefault]]] = [
     (CommonHFKeys.ATTENTION_PROBS_DROPOUT_PROB, None),
+    (CommonHFKeys.DTYPE, HFConfigKeyDefault("float32")),
     (CommonHFKeys.HIDDEN_DROPOUT_PROB, None),
     (CommonHFKeys.HIDDEN_SIZE, None),
     (CommonHFKeys.HIDDEN_ACT, None),

--- a/curated_transformers/models/roberta/config.py
+++ b/curated_transformers/models/roberta/config.py
@@ -16,6 +16,7 @@ class RoBERTaConfig(BERTConfig):
     def __init__(
         self,
         *args,
+        dtype: torch.dtype = torch.float32,
         layer_norm_eps=1e-05,
         n_positions=514,
         padding_id=1,
@@ -24,6 +25,8 @@ class RoBERTaConfig(BERTConfig):
         **kwargs
     ):
         """
+        :param dtype:
+            Data type to use for model parameters.
         :param embedding_width:
             Width of the embedding representations.
         :param hidden_width:
@@ -63,5 +66,5 @@ class RoBERTaConfig(BERTConfig):
             n_pieces=n_pieces,
             **kwargs
         )
-        self.dtype = torch.float32
+        self.dtype = dtype
         self.padding_id = padding_id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

In some applications (e.g. spaCy Curated Transformers), we may already have constructed the model and we want to load parameters in-place. This change adds in-place versions of the `from_*` class methods.

To support this properly, the in-place loaders should not need to access the configuration anymore. So, the Torch dtype deserialization has moved from the `from_repo` method to the configuration deserialization. To support this, all model configurations now also take a `dtype` parameter.

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
