### PR TITLE
Fix activation lookup with Python 3.12.3

### DIFF
--- a/curated_transformers/layers/activations.py
+++ b/curated_transformers/layers/activations.py
@@ -1,5 +1,5 @@
 import math
-from enum import Enum, EnumMeta
+from enum import Enum
 from typing import Type
 
 import torch
@@ -7,46 +7,7 @@ from torch import Tensor
 from torch.nn import Module
 
 
-class _ActivationMeta(EnumMeta):
-    """
-    ``Enum`` metaclass to override the class ``__call__`` method with a more
-    fine-grained exception for unknown activation functions.
-    """
-
-    def __call__(
-        cls,
-        value,
-        names=None,
-        *,
-        module=None,
-        qualname=None,
-        type=None,
-        start=1,
-    ):
-        # Wrap superclass __call__ to give a nicer error message when
-        # an unknown activation is used.
-        if names is None:
-            try:
-                return EnumMeta.__call__(
-                    cls,
-                    value,
-                    names,
-                    module=module,
-                    qualname=qualname,
-                    type=type,
-                    start=start,
-                )
-            except ValueError:
-                supported_activations = ", ".join(sorted(v.value for v in cls))
-                raise ValueError(
-                    f"Invalid activation function `{value}`. "
-                    f"Supported functions: {supported_activations}"
-                )
-        else:
-            return EnumMeta.__call__(cls, value, names, module, qualname, type, start)
-
-
-class Activation(Enum, metaclass=_ActivationMeta):
+class Activation(Enum):
     """
     Activation functions.
 
@@ -70,6 +31,14 @@ class Activation(Enum, metaclass=_ActivationMeta):
 
     #: Sigmoid Linear Unit (`Hendrycks et al., 2016`_).
     SiLU = "silu"
+
+    @classmethod
+    def _missing_(cls, value):
+        supported_activations = ", ".join(sorted(v.value for v in cls))
+        raise ValueError(
+            f"Invalid activation function `{value}`. "
+            f"Supported functions: {supported_activations}"
+        )
 
     @property
     def module(self) -> Type[torch.nn.Module]:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

We used the metaclass `EnumMeta`/`EnumType` to override reporting of missing enum values (to give the full set of supported activations). However, in Python 3.12.3, the default value of the `name` parameter of `EnumType.__call__` method was changed from `None` to `_not_given`:

https://github.com/python/cpython/commit/d771729679d39904768f60b3352e02f5f491966c

Even though this is a public API (which now uses a private default value), it seems too risky to continue using it. So in this change, we implement `Enum.__mising__` instead for the improved error reporting.

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
