### PR TITLE
Fix: ScaledDotProductAttention.forward throws AttributeError when exe…

### DIFF
--- a/curated_transformers/layers/attention.py
+++ b/curated_transformers/layers/attention.py
@@ -708,7 +708,7 @@ class ScaledDotProductAttention(AttentionScorer):
                 key=key,
                 value=value,
                 attn_mask=logit_mask,
-                dropout_p=self.dropout_prob if self.training else 0.0,
+                dropout_p=self.dropout.p if self.training else 0.0,
             )
 
             # Torch SDP returns NaNs for pieces where every is piece masked out.


### PR DESCRIPTION
…cuted within `enable_torch_sdp`

Fixed an AttributeError inside `ScaledDotProductAttention.forward` by accessing the correct attribute.

## Description

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
